### PR TITLE
Fix in-set numbering

### DIFF
--- a/pack/core_encounter.json
+++ b/pack/core_encounter.json
@@ -105,7 +105,7 @@
 		"quantity": 2,
 		"set_code": "rhino",
 		"set_position": 6,
-		"text": "Attach to Rhino.\n<b>Hero Action</b>: Spend [energy] [mental] [physical] resources → discard this card.",
+		"text": "Attach to Rhino.",
 		"traits": "Weapon.",
 		"type_code": "attachment"
 	},
@@ -1069,7 +1069,7 @@
 		"position": 158,
 		"quantity": 1,
 		"set_code": "black_panther_nemesis",
-		"set_position": 4,
+		"set_position": 3,
 		"text": "Surge <i>(After this card resolves, reveal 1 additional encounter card)</i>\n<b>When Revealed</b>: Give the villain and each minion engaged with you a tough status card.",
 		"type_code": "treachery"
 	},
@@ -1230,7 +1230,7 @@
 		"name": "The Vulture's Plans",
 		"pack_code": "core",
 		"position": 169,
-		"quantity": 2,
+		"quantity": 1,
 		"set_code": "spider_man_nemesis",
 		"set_position": 5,
 		"text": "<b>When Revealed</b>: Discard 1 card at random from each player's hand. Place 1 threat on the main scheme for each different resource type discarded this way.",


### PR DESCRIPTION
Fix numbering for Heart-Shaped Herb and The Vulture's Plan.
Remove the extra text on Charge.