### PR TITLE
fix cost of counterattack, it costs 1 not 2 resources

### DIFF
--- a/pack/bkw.json
+++ b/pack/bkw.json
@@ -334,7 +334,7 @@
   },
   {
     "code": "08030",
-    "cost": 2,
+    "cost": 1,
     "deck_limit": 3,
     "faction_code": "aggression",
     "name": "Counterattack",


### PR DESCRIPTION
Noticed that Counterattack cost was incorrect. It's quite obvious when you see the image next to it with a big fat "1" on it :)