### PR TITLE
Add scarlet witch release date

### DIFF
--- a/packs.json
+++ b/packs.json
@@ -151,7 +151,7 @@
 	{
 		"cgdb_id": 15,
 		"code": "scw",
-		"date_release": null,
+		"date_release": "2021-03-05",
 		"name": "Scarlet Witch",
 		"pack_type_code": "hero",
 		"position": 15,


### PR DESCRIPTION
Scarlet Witch release date was missing, which I'm guessing is why Scarlet Witch decks can't be published on marvelcdb.