### PR TITLE
Add the trait "Condition" to Enhanched Physique

### DIFF
--- a/pack/thor.json
+++ b/pack/thor.json
@@ -426,6 +426,7 @@
 		"quantity": 3,
 		"resource_physical": 1,
 		"text": "Uses (3 physical counters).\n<b>Hero Resource</b>: Exhaust Enhanced Physique and remove 1 physical counter from it → generate a [physical] resource.",
+		"traits": "Condition.",
 		"type_code": "upgrade"
 	}
 ]


### PR DESCRIPTION
The trait "Condition" was missing in the data for Enhanced Physique. 