### PR TITLE
Fix missing periods in traits lists that made cards not show up in searches.

### DIFF
--- a/pack/gmw.json
+++ b/pack/gmw.json
@@ -690,7 +690,7 @@
 		"quantity": 3,
 		"resource_physical": 1,
 		"text": "Restricted. Uses (3 charge counters).\n<b>Hero Interrupt</b>: When your hero makes a basic attack, exhaust Hand Cannon and remove 1 charge counter from it → your hero gets +2 ATK for that attack. That attack gains overkill.",
-		"traits": "Tech. Weapon",
+		"traits": "Tech. Weapon.",
 		"type_code": "upgrade"
 	},
 	{
@@ -759,7 +759,7 @@
 		"quantity": 3,
 		"resource_mental": 1,
 		"text": "Play only if your identity has the [[guardian]] trait. Max 1 per player.\n <b>Hero Interrupt</b>: When you would take any amount of damage from an attack, exhaust Booster Boots and discard the top card of your deck → prevent 1 of that damage.",
-		"traits": "Armor. Tech",
+		"traits": "Armor. Tech.",
 		"type_code": "upgrade"
 	}
 ]

--- a/pack/msm.json
+++ b/pack/msm.json
@@ -250,7 +250,7 @@
 		"text": "<b>Interrupt</b>: When an enemy initiates an attack against you, spend a [energy] resource → deal 2 damage to that enemy.",
 		"thwart": 1,
 		"thwart_cost": 1,
-		"traits": "Champion",
+		"traits": "Champion.",
 		"type_code": "ally"
 	},
 	{

--- a/pack/trors.json
+++ b/pack/trors.json
@@ -116,7 +116,7 @@
 		"set_code": "hawkeye",
 		"set_position": 4,
 		"text": "<b>Hero Action</b> <i>(attack)</i>: Exhaust Hawkeye's Bow → confuse an enemy and deal 3 damage to it (5 damage instead if it is already confused)",
-		"traits": "Arrow. Attack",
+		"traits": "Arrow. Attack.",
 		"type_code": "event"
 	},
 	{

--- a/translations/de/pack/msm.json
+++ b/translations/de/pack/msm.json
@@ -88,7 +88,7 @@
 		"name": "Nova",
 		"subname": "Sam Alexander",
 		"text": "<b>Interrupt</b>: When an enemy initiates an attack against you, spend a [energy] resource → deal 2 damage to that enemy.",
-		"traits": "Champion"
+		"traits": "Champion."
 	},
 	{
 		"code": "05014",

--- a/translations/es/pack/core.json
+++ b/translations/es/pack/core.json
@@ -87,7 +87,7 @@
 		"name": "Spiderwoman",
 		"subname": "Jessica Drew",
 		"text": "<b>Respuesta</b>: después de que Spiderwoman entre en juego, confunde al Villano.",
-		"traits": "Vengador, Espía."
+		"traits": "Vengador. Espía."
 	},
 	{
 		"code": "01012",

--- a/translations/es/pack/msm.json
+++ b/translations/es/pack/msm.json
@@ -88,7 +88,7 @@
 		"name": "Nova",
 		"subname": "Sam Alexander",
 		"text": "<b>Interrupción</b>: cuando un enemigo inicie un ataque contra ti, gasta un recurso [energy] → inflige 2 de Daño a ese enemigo.",
-		"traits": "Campeón"
+		"traits": "Campeón."
 	},
 	{
 		"code": "05014",

--- a/translations/fr/pack/gmw.json
+++ b/translations/fr/pack/gmw.json
@@ -226,7 +226,7 @@
         "code": "16046",
         "name": "Canon Portatif",
         "text": "Restreint. Utilisations (3 jetons Charge).\n <b>Interruption de héros</b> : quand votre héros effectue une attaque de base, retirez 1 charge du Canon Portatif et inclinez-le → votre héros gagne +2 ATQ pour cette attaque. Cette attaque gagne Déferlement.",
-        "traits": "Tech. Arme"
+        "traits": "Tech. Arme."
     },
     {
         "code": "16047",
@@ -239,6 +239,6 @@
         "code": "16052",
         "name": "Bottes Propulsées",
         "text": "Jouez cette carte uniquement si votre identité a le trait [[Gardien]].\n1 max par joueur.\n <b>Interruption de héros</b> : quand vous êtes censé subir n'importe quelle quantité de dégâts d'une attaque, inclinez les Bottes Propulsées et défaussez la carte du dessus de votre deck → prévenez 1 de ces dégâts.",
-        "traits": "Armure. Tech"
+        "traits": "Armure. Tech."
     }
 ]

--- a/translations/fr/pack/msm.json
+++ b/translations/fr/pack/msm.json
@@ -87,7 +87,7 @@
         "flavor": "\"Je pense que ma maman se trompait. Toutes ces années passées à jouer aux jeux vidéo ont enfin payé !\"",
         "name": "Nova",
         "text": "<b>Interruption</b> : quand un ennemi initie une attaque contre vous, dépensez une ressource [energy] → infligez 2 dégâts à cet ennemi.",
-        "traits": "Champion",
+        "traits": "Champion.",
         "subname": "Sam Alexander"
     },
     {

--- a/translations/fr/pack/stld.json
+++ b/translations/fr/pack/stld.json
@@ -3,7 +3,7 @@
         "code": "17001a",
         "name": "Star-Lord",
         "text": "Chaque allié que vous contrôlez gagne le trait [[Gardien]].\n<i>\"Qu'est ce qui pourrait mal tourner ?\"</i> — <b>Interruption</b> : quand vous jouez une carte de votre main, attribuez-vous 1 carte Rencontre face cachée → réduisez de 3 le coût en ressources pour jouer cette carte. (Limite d'une fois par round.)",
-        "traits": "Gardien"
+        "traits": "Gardien."
     },
     {
         "code": "17001b",
@@ -87,7 +87,7 @@
         "code": "17013",
         "name": "Yondu",
         "attack_text": "Les attaques de Yondu gagnent À Distance. <i>(Les attaques À Distance ignorent Riposte.)</i>",
-        "traits": "Gardien"
+        "traits": "Gardien."
     },
     {
         "code": "17014",
@@ -118,7 +118,7 @@
         "code": "17020",
         "name": "Cosmo",
         "text": "<b>Interruption</b> : quand Cosmo attaque ou contre, nommez un type de carte, ensuite, défaussez la carte du dessus d'un deck. Si cette carte est du type nommé, Cosmo ne subit pas de dégâts consécutifs <i>(les dégâts indiqués sous CTR ou ATQ)</i> pour cette utilisation.",
-        "traits": "Gardien"
+        "traits": "Gardien."
     },
     {
         "code": "17021",

--- a/translations/fr/pack/twc_encounter.json
+++ b/translations/fr/pack/twc_encounter.json
@@ -8,14 +8,14 @@
     {
         "code": "07002",
         "name": "Le Démolisseur",
-        "traits": "Les Démolisseurs",
+        "traits": "Les Démolisseurs.",
         "attack_text": "Tant que le Démolisseur attaque, il gagne +2 ATQ si l'attaque est non défendue.",
         "scheme_text": "Quand Le Démolisseur manigance, placez les menaces sur sa manigance annexe au lieu de la manigance principale."
     },
     {
         "code": "07003",
         "name": "Le Démolisseur",
-        "traits": "Les Démolisseurs",
+        "traits": "Les Démolisseurs.",
         "attack_text": "Tant que le Démolisseur attaque, il gagne +2 ATQ si l'attaque est non défendue.",
         "scheme_text": "Quand Le Démolisseur manigance, placez les menaces sur sa manigance annexe au lieu de la manigance principale."
     },
@@ -96,14 +96,14 @@
     {
         "code": "07017",
         "name": "Le Boulet",
-        "traits": "Les Démolisseurs",
+        "traits": "Les Démolisseurs.",
         "attack_text": "<b>Réponse forcée</b> : après que le Boulet vous a attaqué, infligez 1 dégât à chaque personnage que vous contrôlez.",
         "scheme_text": "Quand le Boulet manigance, placez les menaces sur sa manigance annexe au lieu de la manigance principale."
     },
     {
         "code": "07018",
         "name": "Le Boulet",
-        "traits": "Les Démolisseurs",
+        "traits": "Les Démolisseurs.",
         "attack_text": "<b>Réponse forcée</b> : après que le Boulet vous a attaqué, infligez 1 dégât à chaque personnage que vous contrôlez.",
         "scheme_text": "Quand le Boulet manigance, placez les menaces sur sa manigance annexe au lieu de la manigance principale."
     },
@@ -186,14 +186,14 @@
         "code": "07032",
         "name": "Le Compresseur",
         "text": "Riposte 1.",
-        "traits": "Les Démolisseurs",
+        "traits": "Les Démolisseurs.",
         "scheme_text": "Quand Le Compresseur manigance, placez les menaces sur sa manigance annexe au lieu de la manigance principale."
     },
     {
         "code": "07033",
         "name": "Le Compresseur",
         "text": "Riposte 1.",
-        "traits": "Les Démolisseurs",
+        "traits": "Les Démolisseurs.",
         "scheme_text": "Quand Le Compresseur manigance, placez les menaces sur sa manigance annexe au lieu de la manigance principale."
     },
     {
@@ -267,14 +267,14 @@
     {
         "code": "07046",
         "name": "Le Bulldozer",
-        "traits": "Les Démolisseurs",
+        "traits": "Les Démolisseurs.",
         "attack_text": "<b>Interruption forcée</b> : quand le Bulldozer attaque, l'attaque gagne Déferlement.",
         "scheme_text": "Quand Le Bulldozer manigance, placez les menaces sur sa manigance annexe au lieu de la manigance principale."
     },
     {
         "code": "07047",
         "name": "Le Bulldozer",
-        "traits": "Les Démolisseurs",
+        "traits": "Les Démolisseurs.",
         "attack_text": "<b>Interruption forcée</b> : quand le Bulldozer attaque, l'attaque gagne Déferlement.",
         "scheme_text": "Quand Le Bulldozer manigance, placez les menaces sur sa manigance annexe au lieu de la manigance principale."
     },

--- a/validate.py
+++ b/validate.py
@@ -47,6 +47,8 @@ def custom_card_check(args, card, pack_code, factions_data, types_data):
         raise jsonschema.ValidationError("Faction code '%s' of the pack '%s' doesn't match any valid faction code." % (card["faction_code"], card["code"]))
     if card.get("type_code") and  card["type_code"] not in [f["code"] for f in types_data]:
         raise jsonschema.ValidationError("Faction code '%s' of the pack '%s' doesn't match any valid type code." % (card["type_code"], card["code"]))
+    if card.get("traits") and not card["traits"].endswith("."):
+        raise jsonschema.ValidationError("The traits list \"%s\" on card %s does not end with a period (.)" % (card["traits"], card["code"]))
 
 def format_json(json_data):
     formatted_data = json.dumps(json_data, ensure_ascii=False, sort_keys=True, indent=4, separators=(',', ': '))


### PR DESCRIPTION
When searching for, "k:Weapon" Hand Cannon should appear in the results but does not.

![NoHandCannon](https://user-images.githubusercontent.com/12694374/127465514-8b9c6b0b-41c5-46eb-9b12-ee81137bebad.PNG)

When I look at Hand Cannon on the website it *looks* correct at first.

![HandCannon](https://user-images.githubusercontent.com/12694374/127465529-9f25e62c-feb1-4d0d-8789-9c2b1d18d38f.PNG)

This seems to be because of a missing period in the json 

`		"traits": "Tech. Weapon",`

it seems like all traits should end with a period based on how the rest of the data is formatted. This theory is supported by how Nova does not show up when searching for "k:Champion" and it has the same error.

I did a regexp-search and tried to find all cards with this problem and fix them.

I also added a check to validate.py to catch most of these errors in the future as well.