### PR TITLE
Add Avengers Tower Card to TRotRS Pack

### DIFF
--- a/pack/trors.json
+++ b/pack/trors.json
@@ -370,20 +370,11 @@
 		"type_code": "ally"
 	},
 	{
-		"code": "03024",
-		"cost": 2,
-		"deck_limit": 1,
-		"faction_code": "basic",
-		"is_unique": true,
-		"name": "Avengers Tower",
-		"octgn_id": "cf838165-508c-42b9-a8d3-92238741b795",
+		"code": "04021",
+		"duplicate_of": "03024",
 		"pack_code": "trors",
 		"position": 21,
-		"quantity": 1,
-		"resource_mental": 1,
-		"text": "If each of your allies has the [[Avenger]] trait, increase your ally limit by 1.\n<b>Action:</b> Exhaust Avengers Tower → reduce the cost of the next [[Avenger]] ally played this phase by 1.",
-		"traits": "Location.",
-		"type_code": "support"
+		"quantity": 1
 	},
 	{
 		"code": "04022",

--- a/pack/trors.json
+++ b/pack/trors.json
@@ -370,6 +370,22 @@
 		"type_code": "ally"
 	},
 	{
+		"code": "03024",
+		"cost": 2,
+		"deck_limit": 1,
+		"faction_code": "basic",
+		"is_unique": true,
+		"name": "Avengers Tower",
+		"octgn_id": "cf838165-508c-42b9-a8d3-92238741b795",
+		"pack_code": "trors",
+		"position": 21,
+		"quantity": 1,
+		"resource_mental": 1,
+		"text": "If each of your allies has the [[Avenger]] trait, increase your ally limit by 1.\n<b>Action:</b> Exhaust Avengers Tower → reduce the cost of the next [[Avenger]] ally played this phase by 1.",
+		"traits": "Location.",
+		"type_code": "support"
+	},
+	{
 		"code": "04022",
 		"cost": 0,
 		"deck_limit": 3,


### PR DESCRIPTION
This should fix zzorba/marvelsdb#118.

According to Hall of Heroes, the TRotRS card doesn't have the avenger trait, while the card from the Captain America pack does.

I am not sure if the card should have a unique code/ID if they will be considered two different cards due to the trait difference.