### PR TITLE
Update data for The Hood modular sets - Part 1

### DIFF
--- a/pack/hood_encounter.json
+++ b/pack/hood_encounter.json
@@ -204,7 +204,7 @@
 		"quantity": 1,
 		"set_code": "the_hood",
 		"set_position": 12,
-		"text": "Hinder 2 [per_hero]. <i>(When revealed, place 2 [per_hero] threat here.)</i>\n<b>Forced Interrupt:</b> When the villain phase begins, each player must resolve The Hood's \"Foul Play\" ability in player order.",
+		"text": "Hinder 2[per_hero]. <i>(When revealed, place 2[per_hero] threat here.)</i>\n<b>Forced Interrupt:</b> When the villain phase begins, each player must resolve The Hood's \"Foul Play\" ability in player order.",
 		"type_code": "side_scheme"
 	},
 	{

--- a/pack/hood_encounter.json
+++ b/pack/hood_encounter.json
@@ -309,9 +309,11 @@
 	{
 		"attack": 1,
 		"boost": 1,
+		"boost_text": "After this activation ends, put Brothers Grimm into play engaged with the first player.",
 		"code": "24018",
 		"faction_code": "encounter",
 		"health": 8,
+		"illustrator": "Patrick McEvoy",
 		"is_unique": true,
 		"name": "Brothers Grimm",
 		"octgn_id": "2a6dcbcd-c8a0-4b06-8213-c20b66a2b337",
@@ -321,6 +323,7 @@
 		"scheme": 1,
 		"set_code": "brothers_grimm",
 		"set_position": 1,
+		"text": "[star]<b>Forced Interrupt:</b> When Brothers Grimm activates against you, discard cards from the top of the encounter deck until an attachment is discarded. Reveal that card.",
 		"traits": "Masters of Evil. Mystic.",
 		"type_code": "minion"
 	},
@@ -328,6 +331,7 @@
 		"boost": 0,
 		"code": "24019",
 		"faction_code": "encounter",
+		"illustrator": "Patrick McEvoy",
 		"name": "Blackbird Pellets",
 		"octgn_id": "4d2e4a0a-4148-4e40-9eae-a46c394f0ba1",
 		"pack_code": "hood",
@@ -335,6 +339,7 @@
 		"quantity": 1,
 		"set_code": "brothers_grimm",
 		"set_position": 2,
+		"text": "Attach to a [[Mystic]] minion. If you cannot, attach to the villain.\n[star]<b>Forced Response:</b> After attached enemy activates against you, discard this card → discard 1 card at random from your hand and deal yourself 1 facedown encounter card.",
 		"traits": "Item.",
 		"type_code": "attachment"
 	},
@@ -342,6 +347,7 @@
 		"boost": 1,
 		"code": "24020",
 		"faction_code": "encounter",
+		"illustrator": "Andrea Di Vitto & Laura Villari",
 		"name": "Corrosive Egg Bomb",
 		"octgn_id": "d4300180-9e71-43ad-b0c3-8390edf5c380",
 		"pack_code": "hood",
@@ -349,6 +355,7 @@
 		"quantity": 1,
 		"set_code": "brothers_grimm",
 		"set_position": 3,
+		"text": "Attach to a [[Mystic]] minion. If you cannot, attach to the villain.\n[star]<b>Forced Response:</b> After attached enemy activates against you, discard this card → take 3 indirect damage and deal yourself 1 facedown encounter card.",
 		"traits": "Item.",
 		"type_code": "attachment"
 	},
@@ -356,6 +363,7 @@
 		"boost": 2,
 		"code": "24021",
 		"faction_code": "encounter",
+		"illustrator": "Patrick McEvoy",
 		"name": "Paralytic Stardust",
 		"octgn_id": "a389a765-3e40-4a66-b78f-83d53d34eb3a",
 		"pack_code": "hood",
@@ -363,6 +371,7 @@
 		"quantity": 1,
 		"set_code": "brothers_grimm",
 		"set_position": 4,
+		"text": "Attach to a [[Mystic]] minion. If you cannot, attach to the villain.\n[star]<b>Forced Response:</b> After attached enemy activates against you, discard this card → stun your identity and deal yourself 1 facedown encounter card.",
 		"traits": "Item.",
 		"type_code": "attachment"
 	},
@@ -370,6 +379,7 @@
 		"boost": 3,
 		"code": "24022",
 		"faction_code": "encounter",
+		"illustrator": "Andrea Di Vitto & Laura Villari",
 		"name": "Unbreakable Thread",
 		"octgn_id": "c5c3480c-967d-4e52-885f-004da7048053",
 		"pack_code": "hood",
@@ -377,6 +387,7 @@
 		"quantity": 1,
 		"set_code": "brothers_grimm",
 		"set_position": 5,
+		"text": "Attach to a [[Mystic]] minion. If you cannot, attach to the villain.\n[star]<b>Forced Response:</b> After attached enemy activates against you, discard this card → choose and discard 1 ally, support, or upgrade you control and deal yourself 1 facedown encounter card.",
 		"traits": "Item.",
 		"type_code": "attachment"
 	},

--- a/pack/hood_encounter.json
+++ b/pack/hood_encounter.json
@@ -17,7 +17,7 @@
 		"set_code": "the_hood",
 		"set_position": 1,
 		"stage": 1,
-		"text": "<i>Foul Play</b> - <b>Special:</b> Discard the top card of the encounter deck. If that card does not belong to The Hood encounter set, deal it to yourself as a facedown encounter card.",
+		"text": "<i>Foul Play</i> - <b>Special:</b> Discard the top card of the encounter deck. If that card does not belong to The Hood encounter set, deal it to yourself as a facedown encounter card.",
 		"traits": "Criminal.",
 		"type_code": "villain"
 	},
@@ -38,7 +38,7 @@
 		"set_code": "the_hood",
 		"set_position": 2,
 		"stage": 2,
-		"text": "<b>When Defeated:</b> Choose 1 set-aside modular encounter set at random, then shuffle it into the encounter deck.\n\n<i>Foul Play</b> - <b>Special:</b> Discard the top 2 cards of the encounter deck. Deal the first card discarded this way that does not belong to The Hood encounter set to yourself as a facedown encounter card.",
+		"text": "<b>When Defeated:</b> Choose 1 set-aside modular encounter set at random, then shuffle it into the encounter deck.\n\n<i>Foul Play</i> - <b>Special:</b> Discard the top 2 cards of the encounter deck. Deal the first card discarded this way that does not belong to The Hood encounter set to yourself as a facedown encounter card.",
 		"traits": "Criminal.",
 		"type_code": "villain"
 	},
@@ -59,7 +59,7 @@
 		"set_code": "the_hood",
 		"set_position": 3,
 		"stage": 3,
-		"text": "<b>When Defeated:</b> Choose 1 set-aside modular encounter set at random, then shuffle it into the encounter deck.\n\n<i>Foul Play</b> - <b>Special:</b> Discard the top 2 cards of the encounter deck. Deal each card discarded this way that does not belong to The Hood encounter set to yourself as a facedown encounter card.",
+		"text": "<b>When Defeated:</b> Choose 1 set-aside modular encounter set at random, then shuffle it into the encounter deck.\n\n<i>Foul Play</i> - <b>Special:</b> Discard the top 2 cards of the encounter deck. Deal each card discarded this way that does not belong to The Hood encounter set to yourself as a facedown encounter card.",
 		"traits": "Criminal.",
 		"type_code": "villain"
 	},

--- a/pack/hood_encounter.json
+++ b/pack/hood_encounter.json
@@ -238,10 +238,10 @@
 	},
 	{
 		"base_threat": 3,
-		"base_threat_fixed": 0,
 		"boost": 3,
 		"code": "24014",
 		"faction_code": "encounter",
+		"flavor": "\"The only good superhero is a dead one.\" - Griffin",
 		"name": "Beast Mode",
 		"octgn_id": "ae7f6bad-79b9-4278-9cdc-c9ed4e258f98",
 		"pack_code": "hood",
@@ -249,10 +249,12 @@
 		"quantity": 1,
 		"set_code": "beasty_boys",
 		"set_position": 1,
+		"text": "<b>Forced Interrupt:</b> When a stunned or confused friendly character would take any amount of damage, increase that amount by 1.",
 		"type_code": "side_scheme"
 	},
 	{
 		"attack": 3,
+		"attack_text": "<b>Forced Response</b>: After Griffin attacks and damages a character, stun that character.",
 		"boost": 2,
 		"code": "24015",
 		"faction_code": "encounter",
@@ -266,6 +268,7 @@
 		"scheme": 1,
 		"set_code": "beasty_boys",
 		"set_position": 2,
+		"text": "Quickstrike.\n<b>When Defeated:</b> If there is a stunned friendly character in play, shuffle Griffin into the encounter deck.",
 		"traits": "Brute. Masters of Evil.",
 		"type_code": "minion"
 	},
@@ -275,6 +278,7 @@
 		"code": "24016",
 		"faction_code": "encounter",
 		"health": 6,
+		"illustrator": "Patrick McEvoy",
 		"is_unique": true,
 		"name": "Mandrill",
 		"octgn_id": "e1cd93ce-e97c-47a0-9d71-dfb7cf097e25",
@@ -284,11 +288,12 @@
 		"scheme": 2,
 		"set_code": "beasty_boys",
 		"set_position": 3,
+		"text": "Mandrill gains retaliate X, where X is equal to the number of confused characters <i>(friendly or enemy)</i> in play.\n<b>When Revealed:</b> Confuse each character you control.",
 		"traits": "Brute. Crossfire's Crew.",
 		"type_code": "minion"
 	},
 	{
-		"boost": 0,
+		"boost_text": "Resolve this card's \"<b>When Revealed</b>\" ability.",
 		"code": "24017",
 		"faction_code": "encounter",
 		"name": "Double Trouble",
@@ -298,6 +303,7 @@
 		"quantity": 1,
 		"set_code": "beasty_boys",
 		"set_position": 4,
+		"text": "<b>When Revealed:</b> Stun a character you control. Confuse a character you control.",
 		"type_code": "treachery"
 	},
 	{


### PR DESCRIPTION
**Modulars updated:**
* Beasty Boys
* Brothers Grimm

**Also:** 
* Fixes issue with tag incorrectly closed on the The Hood villain text
* Fixes Hinder (per hero) definition to remove unnecessary spaces