### PR TITLE
[FR]: fix sets broken json

### DIFF
--- a/translations/fr/sets.json
+++ b/translations/fr/sets.json
@@ -363,6 +363,7 @@
     "code": "master_mold",
     "name": "Moule Initial"
   },
+  {
     "code": "masters_of_evil",
     "name": "Maîtres du Mal"
   },
@@ -391,7 +392,6 @@
     "name": "Campage L'Ombre du Titan Fou"
   },
   {
-  {
     "code": "mut_gen",
     "name": "La Genèse des Mutants"
   },
@@ -399,6 +399,7 @@
     "code": "mut_gen_campaign",
     "name": "Campagne La Genèse des Mutants"
   },
+  {
     "code": "mutagen_formula",
     "name": "Formule Mutagène"
   },
@@ -444,7 +445,7 @@
   },
   {
     "code": "phoenix",
-    "name": "Phénix",
+    "name": "Phénix"
   },
   {
     "code": "phoenix_nemesis",
@@ -641,7 +642,7 @@
   {
     "code": "streets_of_mayhem",
     "name": "Rues Malfamées"
-  },},
+  },
   {
     "code": "symbiotic_strength",
     "name": "Force Symbiotique"


### PR DESCRIPTION
In FR translated JSON, the sets.json file is completely broken: Missing brackets, missing quotes etc. 
This can be an incidence if a user want to parse this Json file.

@SlyMCFr If you want to check this PR :) 

