### PR TITLE
Turn on validation for encounter cards

### DIFF
--- a/pack/mts_encounter.json
+++ b/pack/mts_encounter.json
@@ -133,7 +133,7 @@
 		"code": "21069",
 		"faction_code": "encounter",
 		"health": 4,
-		"name": "Zealot of thuth",
+		"name": "Zealot of Truth",
 		"octgn_id": "1c5e678e-9214-4b41-afb5-b6a1764fd2d5",
 		"pack_code": "mts",
 		"position": 69,
@@ -141,8 +141,8 @@
 		"scheme": 1,
 		"set_code": "warlock_nemesis",
 		"set_position": 3,
-		"text": "Threat cannot be removed from the Church of thuth side scheme.",
-		"traits": "Mystic",
+		"text": "Threat cannot be removed from the Universal Church of Truth side scheme.",
+		"traits": "Mystic.",
 		"type_code": "minion"
 	},
 	{
@@ -1348,7 +1348,7 @@
 	},
 	{
 		"back_name": "Odin's Torment",
-		"back_text": "",
+		"back_text": "<b> Contents: </b> Villain deck Hela A (Hela B instead for expert mode). Hela and standard sets. Two modular encounter sets (Legions of Hel and Frost Giants).\n<b> Setup: </b> Attach Odin to the main scheme, [[captive]] side faceup. Reveal Gnipahellir and Garm. Set Gjallerbru, Skurge, Hall of Nastrond, and Nidhogg aside, out of play. Shuffle the encounter deck.",
 		"base_threat": 1,
 		"code": "21138",
 		"double_sided": true,
@@ -1359,11 +1359,10 @@
 		"pack_code": "mts",
 		"position": 138,
 		"quantity": 1,
-		"scheme_text": "<b> Contents: </b> Villain deck Hela A (Hela Be instead for expert mode). Hela and standard sets. Two modular encounter sets (Legions of Hel and Frost Giants).\n<b> Setup: </b> Attach Odin to the main scheme, [[captive]] side faceup. Reveal Gnipahellir and Garm. Set Gjallerbru, Skurge, Hall of Nastrond, and Nidhogg aside, out of play. Shuffle the encounter deck.",
 		"set_code": "hela",
 		"set_position": 3,
 		"stage": 1,
-		"text": "Hela cannot be defeated.\n<b> Forced Response: </b> After a side scheme is defeated, flip Hela to her [[mystic]] side.",
+		"text": "<b> Forced Interrupt: </b> When Hela would be defeated, if Odin is attached to this scheme, discard each attachment from Hela and flip her to her [[wounded]] side instead.\n<b> If this scheme is completed, the players lose the game. </b>",
 		"threat": 18,
 		"type_code": "main_scheme"
 	},

--- a/pack/mut_gen_encounter.json
+++ b/pack/mut_gen_encounter.json
@@ -164,7 +164,7 @@
 		"set_code": "sabretooth",
 		"set_position": 1,
 		"stage": "1",
-		"traits": "Brotherhood of Mutant",
+		"traits": "Brotherhood of Mutants.",
 		"type_code": "villain"
 	},
 	{
@@ -184,7 +184,7 @@
 		"set_position": 2,
 		"stage": "2",
 		"text": "Toughness.",
-		"traits": "Brotherhood of Mutant",
+		"traits": "Brotherhood of Mutants.",
 		"type_code": "villain"
 	},
 	{
@@ -204,7 +204,7 @@
 		"set_position": 3,
 		"stage": "3",
 		"text": "Retaliate 1. Toughness.",
-		"traits": "Brotherhood of Mutant",
+		"traits": "Brotherhood of Mutants.",
 		"type_code": "villain"
 	},
 	{

--- a/translations/de/pack/mut_gen_encounter.json
+++ b/translations/de/pack/mut_gen_encounter.json
@@ -64,19 +64,19 @@
 	{
 		"code": "32060",
 		"name": "Sabretooth I",
-		"traits": "Brotherhood of Mutant"
+		"traits": "Brotherhood of Mutants."
 	},
 	{
 		"code": "32061",
 		"name": "Sabretooth II",
 		"text": "Toughness.",
-		"traits": "Brotherhood of Mutant"
+		"traits": "Brotherhood of Mutants."
 	},
 	{
 		"code": "32062",
 		"name": "Sabretooth III",
 		"text": "Retaliate 1. Toughness.",
-		"traits": "Brotherhood of Mutant"
+		"traits": "Brotherhood of Mutants."
 	},
 	{
 		"code": "32063a",

--- a/translations/es/pack/mut_gen.json
+++ b/translations/es/pack/mut_gen.json
@@ -10,7 +10,7 @@
 		"code": "32001b",
 		"name": "Piotr Rasputin",
 		"text": "<b>Preparación</b>: busca en tu mazo una copia de Acero orgánico y añádela a tu mano.\n<i>Artista en ciernes</i> - <b>Respuesta</b>: después de que cambies a esta identidad, coge 1 carta de Coloso que esté en tu pila de descartes, añádela a tu mazo y barájalo.",
-		"traits": "Mutantee."
+		"traits": "Mutante."
 	},
 	{
 		"code": "32002",
@@ -311,7 +311,7 @@
 		"name": "Magneto",
 		"subname": "Erik Lensherr",
 		"text": "Victory 1.",
-		"traits": "Brotherhood of Mutants.",
+		"traits": "Brotherhood of Mutantes.",
 		"type_code": "ally"
 	},
 	{

--- a/translations/es/pack/mut_gen.json
+++ b/translations/es/pack/mut_gen.json
@@ -311,7 +311,7 @@
 		"name": "Magneto",
 		"subname": "Erik Lensherr",
 		"text": "Victory 1.",
-		"traits": "Brotherhood of Mutantes.",
+		"traits": "Brotherhood of Mutants.",
 		"type_code": "ally"
 	},
 	{

--- a/translations/it/pack/mut_gen_encounter.json
+++ b/translations/it/pack/mut_gen_encounter.json
@@ -49,19 +49,19 @@
 	{
 		"code": "32060",
 		"name": "Sabretooth I",
-		"traits": "Brotherhood of Mutant"
+		"traits": "Brotherhood of Mutants."
 	},
 	{
 		"code": "32061",
 		"name": "Sabretooth II",
 		"text": "Toughness.",
-		"traits": "Brotherhood of Mutant"
+		"traits": "Brotherhood of Mutants."
 	},
 	{
 		"code": "32062",
 		"name": "Sabretooth III",
 		"text": "Retaliate 1. Toughness.",
-		"traits": "Brotherhood of Mutant"
+		"traits": "Brotherhood of Mutants."
 	},
 	{
 		"code": "32063a",

--- a/translations/ko/pack/mts_encounter.json
+++ b/translations/ko/pack/mts_encounter.json
@@ -49,9 +49,9 @@
 	{
 		"boost_text": "<b>Boost</b>: Put Zealot of Truth into play engaged with you.",
 		"code": "21069",
-		"name": "Zealot of thuth",
-		"text": "Threat cannot be removed from the Church of thuth side scheme.",
-		"traits": "Mystic"
+		"name": "Zealot of Truth",
+		"text": "Threat cannot be removed from the Universal Church of Truth side scheme.",
+		"traits": "Mystic."
 	},
 	{
 		"code": "21070",

--- a/validate.py
+++ b/validate.py
@@ -47,8 +47,8 @@ def custom_card_check(args, card, pack_code, factions_data, types_data):
         raise jsonschema.ValidationError("Faction code '%s' of the pack '%s' doesn't match any valid faction code." % (card["faction_code"], card["code"]))
     if card.get("type_code") and  card["type_code"] not in [f["code"] for f in types_data]:
         raise jsonschema.ValidationError("Faction code '%s' of the pack '%s' doesn't match any valid type code." % (card["type_code"], card["code"]))
-    if card.get("traits") and not card["traits"].endswith("."):
-        raise jsonschema.ValidationError("The traits list \"%s\" on card %s does not end with a period (.)" % (card["traits"], card["code"]))
+    if card.get("traits") and not re.search("[\.!\d]$", card["traits"]):
+        raise jsonschema.ValidationError("The traits list \"%s\" on card %s does not end with a period (.), exclamation point (!), or number (0-9)." % (card["traits"], card["code"]))
 
 def format_json(json_data):
     formatted_data = json.dumps(json_data, ensure_ascii=False, sort_keys=True, indent=4, separators=(',', ': '))
@@ -202,7 +202,7 @@ def validate_cards(args, packs_data, factions_data, types_data):
             verbose_print(args, "Validating encounter cards...\n", 1)
             pack_path = os.path.join(args.pack_path, "{}_encounter.json".format(p["code"]))
             pack_data = load_json_file(args, pack_path)
-            if not pack_data:
+            if pack_data:
                 for card in pack_data:
                     validate_card(args, card, CARD_SCHEMA, p["code"], factions_data, types_data)
 


### PR DESCRIPTION
I found out that the encounter cards haven't been validated from the initial commit because of an extra `not`. Once I removed that and validated the encounter cards, I found several errors that I tried to fix.

The biggest issue is that not all Traits end in a period (.), although nearly every one does. I found a few that end in an exclamation point (!) and then the Sinister Six villains end in activation numbers (Activation Order 1, Activation Order 2, etc). I updated the validation script to allow for these situations by adding a regex to check for period, exclamation point, or numbers as the trailing character.

With Odin's Torment (21138), the back_text was invalid so I tried to fix it. It looks like maybe a few villain scheme cards might be backwards by using the back_text and text in the wrong order. I might try to fix those next week.