### PR TITLE
Fix Yon-Rogg text by closing bold tag

### DIFF
--- a/pack/core_encounter.json
+++ b/pack/core_encounter.json
@@ -1456,7 +1456,7 @@
 	},
 	{
 		"attack": 3,
-		"attack_text": "<b>Forced Response/b>: After Yon-Rogg attacks, place 1 threat on The Psych-Magnitron.",
+		"attack_text": "<b>Forced Response</b>: After Yon-Rogg attacks, place 1 threat on The Psych-Magnitron.",
 		"boost": 2,
 		"code": "01177",
 		"faction_code": "encounter",

--- a/translations/de/pack/core_encounter.json
+++ b/translations/de/pack/core_encounter.json
@@ -524,7 +524,7 @@
 		"text": "<b>Sobald aufgedeckt</b>: Platziere hier zusätzlich 1 [per_hero] Bedrohung."
 	},
 	{
-		"attack_text": "<b>Erzwungene Reaktion/b>: Nachdem Yon-Rogg angegriffen hat, platziere 1 Bedrohung auf Das Psyche-Magnetron.\n<i>(Captain Marvels Erzfeind-Scherge.)</i>",
+		"attack_text": "<b>Erzwungene Reaktion</b>: Nachdem Yon-Rogg angegriffen hat, platziere 1 Bedrohung auf Das Psyche-Magnetron.\n<i>(Captain Marvels Erzfeind-Scherge.)</i>",
 		"code": "01177",
 		"flavor": "\"Du bist nicht mächtig, wenn du nicht gefürchtet wirst.\"",
 		"name": "Yon-Rogg"

--- a/translations/fr/pack/core_encounter.json
+++ b/translations/fr/pack/core_encounter.json
@@ -525,7 +525,7 @@
 		"text": "<b>Une fois révélée</b> : placez 1[per_hero] menace supplémentaire sur cette carte."
 	},
 	{
-		"attack_text": "<b>Réponse forcée/b> : après que Yon-Rogg a attaqué, placez 1 menace sur le Psycho-Magnitron.",
+		"attack_text": "<b>Réponse forcée</b> : après que Yon-Rogg a attaqué, placez 1 menace sur le Psycho-Magnitron.",
 		"code": "01177",
 		"flavor": "\"Vous n'avez pas réellement de pouvoir tant qu'ils ne vous craignent pas.\"",
 		"name": "Yon-Rogg",

--- a/translations/it/pack/twc_encounter.json
+++ b/translations/it/pack/twc_encounter.json
@@ -22,7 +22,7 @@
 	{
 		"code": "07004",
 		"name": "Resa dei Conti",
-		"text": "<b><i>Trama secondaria di Demolitore.</i></b>\n<i>Mentre Demolitore è in gioco, questa carta non può uscire dal gioco.</i>\n<i>Picchia Duro</i> -- <b>Risposta Obbligata:/b>: Dopo che 1 o più minacce sono state collocate su questa trama, se ci sono 10 o più minacce su questa trama, infliggi 2 danni a ogni personaggio amico. Rimuovi da questa trama tutte le minacce tranne 3,"
+		"text": "<b><i>Trama secondaria di Demolitore.</i></b>\n<i>Mentre Demolitore è in gioco, questa carta non può uscire dal gioco.</i>\n<i>Picchia Duro</i> -- <b>Risposta Obbligata:</b>: Dopo che 1 o più minacce sono state collocate su questa trama, se ci sono 10 o più minacce su questa trama, infliggi 2 danni a ogni personaggio amico. Rimuovi da questa trama tutte le minacce tranne 3,"
 	},
 	{
 		"code": "07005",


### PR DESCRIPTION
[Yon-Rogg 01177](https://marvelcdb.com/card/01177) has a typo in the attack text where the bold tag isn't closed so most of the text is bolded. I'm closing the bold tag in the English, French, and German packs.

I did a global search for non-closed b tags and found another example for [Day of Reckoning 07004](https://marvelcdb.com/card/07004) in the Italian pack so I fixed that too.