### PR TITLE
Add missing TRORS cards

### DIFF
--- a/pack/trors.json
+++ b/pack/trors.json
@@ -356,6 +356,20 @@
 		"type_code": "event"
 	},
 	{
+		"code": "04018",
+		"duplicate_of": "01070",
+		"pack_code": "trors",
+		"position": 17,
+		"quantity": 2
+	},
+	{
+		"code": "04019",
+		"duplicate_of": "01072",
+		"pack_code": "trors",
+		"position": 19,
+		"quantity": 2
+	},
+	{
 		"attack": 2,
 		"attack_cost": 1,
 		"code": "04020",
@@ -399,6 +413,27 @@
 		"text": "<b>Hero Action</b>: Exhaust an [[avenger]] character you control → ready another [[avenger]] character you control.",
 		"traits": "",
 		"type_code": "event"
+	},
+	{
+		"code": "04023",
+		"duplicate_of": "01088",
+		"pack_code": "trors",
+		"position": 23,
+		"quantity": 1
+	},
+	{
+		"code": "04024",
+		"duplicate_of": "01089",
+		"pack_code": "trors",
+		"position": 24,
+		"quantity": 1
+	},
+	{
+		"code": "04025",
+		"duplicate_of": "01090",
+		"pack_code": "trors",
+		"position": 25,
+		"quantity": 1
 	},
 	{
 		"attack": 1,
@@ -626,6 +661,20 @@
 		"type_code": "ally"
 	},
 	{
+		"code": "04041",
+		"duplicate_of": "01057",
+		"pack_code": "trors",
+		"position": 41,
+		"quantity": 2
+	},
+	{
+		"code": "04042",
+		"duplicate_of": "01056",
+		"pack_code": "trors",
+		"position": 42,
+		"quantity": 2
+	},
+	{
 		"code": "04043",
 		"cost": 1,
 		"deck_limit": 3,
@@ -680,6 +729,13 @@
 		"type_code": "ally"
 	},
 	{
+		"code": "04046",
+		"duplicate_of": "01065",
+		"pack_code": "trors",
+		"position": 46,
+		"quantity": 2
+	},
+	{
 		"code": "04047",
 		"cost": 0,
 		"deck_limit": 3,
@@ -693,6 +749,13 @@
 		"text": "Play under any player's control. Max 1 per player.\n<b>Hero Response</b>: After a side scheme is defeated, exhaust Skilled Investigator → draw 1 card.",
 		"traits": "Skill.",
 		"type_code": "upgrade"
+	},
+	{
+		"code": "04048",
+		"duplicate_of": "01063",
+		"pack_code": "trors",
+		"position": 48,
+		"quantity": 2
 	},
 	{
 		"code": "04049",
@@ -709,6 +772,27 @@
 		"text": "<b>Hero Action</b> <i>(thwart)</i>: Remove 2 threat from a scheme. If this removes the last threat on that scheme, draw 1 card.",
 		"traits": "Thwart.",
 		"type_code": "event"
+	},
+	{
+		"code": "04050",
+		"duplicate_of": "01088",
+		"pack_code": "trors",
+		"position": 50,
+		"quantity": 1
+	},
+	{
+		"code": "04051",
+		"duplicate_of": "01089",
+		"pack_code": "trors",
+		"position": 51,
+		"quantity": 1
+	},
+	{
+		"code": "04052",
+		"duplicate_of": "01090",
+		"pack_code": "trors",
+		"position": 52,
+		"quantity": 1
 	},
 	{
 		"code": "04155",


### PR DESCRIPTION
I've updated the The Rise of Red Skull (TRORS) pack to include missing cards. This should fix https://github.com/zzorba/marvelsdb/issues/177.

I've added (all of these are duplicate cards that were already in other packs):
* Lead from the Front (04018)
* The Power of Leadership (04019)
* Energy (04023)
* Genius (04024)
* Strength (04025)
* Combat Training (04041)
* Tac Team (04042)
* Heroic Intuition (04046)
* Interrogation Room (04048)
* Energy (04050)
* Genius (04051)
* Strength (04052)

I think the pack position numbers might have been typos on some of them when they were published. For example, both the existing Ready for Action (04017) and the new Lead from the Front (04018) have position 17. I think the Resource cards might also be a little off with their pack position numbers.