### PR TITLE
Add a new player_side_scheme card type

### DIFF
--- a/types.json
+++ b/types.json
@@ -58,5 +58,9 @@
 	{
 		"code": "environment",
 		"name": "Environment"
+	},
+	{
+		"code": "player_side_scheme",
+		"name": "Player Side Scheme"
 	}
 ]


### PR DESCRIPTION
I'm adding a new `player_side_scheme` card type in preparation for the NeXt Evolution campaign box that comes out in August.

I also have a related https://github.com/zzorba/marvelsdb/pull/184 PR that adds the support to the marvelsdb repo.