### PR TITLE
Fix the German version of 31021

### DIFF
--- a/translations/de/pack/spdr.json
+++ b/translations/de/pack/spdr.json
@@ -135,7 +135,7 @@
 		"traits": "Superkraft."
 	},
 	{
-		"code": "30021",
+		"code": "31021",
 		"name": "Spider-Ham",
 		"subname": "Peter Porker",
 		"text": "Spiele diese Karte nur, falls du eine [[Web-Warrior]]-Karte kontrollierst.\n[star] <b>Erzwungene Reaktion</b>: Nachdem Spider-Ham angegriffen oder Widerstand geleistet hat, lege die oberste Karte des Begegnungsdecks ab. Füge Spider-Ham für jedes auf diese Weise abgelegte Boost-Symbol ([boost]) 1 Schaden zu.",


### PR DESCRIPTION
The German translation for the Spider-Ham ally (31021) was mistakenly linked to the SP//DR ally (30021). This caused the SP//DR ally to have Spider-Ham text and it caused the Spider-Ham ally to only have English text since the German translation wasn't linked to the card.

Both should now be fixed. This also addresses issue https://github.com/zzorba/marvelsdb/issues/178.

https://de.marvelcdb.com/card/30021
https://de.marvelcdb.com/card/31021