### PR TITLE
Make meta property required for hero card types

### DIFF
--- a/pack/ant.json
+++ b/pack/ant.json
@@ -63,6 +63,15 @@
 		"health": 12,
 		"illustrator": "Patrick McEvoy",
 		"is_unique": true,
+		"meta": {
+			"colors": [
+				"#949599",
+				"#b1222b",
+				"#1e2122",
+				"#fffffd"
+			],
+			"offset": "-35px -33px"
+		},
 		"name": "Ant-Man",
 		"octgn_id": "b768a53b-cb8c-47c5-9b65-f20ed2d89837",
 		"pack_code": "ant",

--- a/pack/ironheart.json
+++ b/pack/ironheart.json
@@ -60,6 +60,14 @@
 		"hidden": false,
 		"illustrator": "Joey Vasquez",
 		"is_unique": true,
+		"meta": {
+			"colors": [
+				"#9c255d",
+				"#252c36",
+				"#dba627",
+				"#fffffd"
+			]
+		},
 		"name": "Ironheart",
 		"octgn_id": "82e28243-edbd-439d-b5e6-5841ab87db96",
 		"pack_code": "ironheart",
@@ -103,6 +111,14 @@
 		"hidden": false,
 		"illustrator": "Joey Vasquez",
 		"is_unique": true,
+		"meta": {
+			"colors": [
+				"#9c255d",
+				"#252c36",
+				"#dba627",
+				"#fffffd"
+			]
+		},
 		"name": "Ironheart",
 		"octgn_id": "a24f1149-87bf-4eef-90f8-992b22b2039b",
 		"pack_code": "ironheart",

--- a/pack/wsp.json
+++ b/pack/wsp.json
@@ -63,6 +63,15 @@
 		"health": 11,
 		"illustrator": "Patrick McEvoy",
 		"is_unique": true,
+		"meta": {
+			"colors": [
+				"#b42328",
+				"#221e25",
+				"#8c979b",
+				"#fffffd"
+			],
+			"offset": "-38px -33px"
+		},
 		"name": "Wasp",
 		"octgn_id": "8f023a00-d5d2-4ae6-ade7-3418e0b6f160",
 		"pack_code": "wsp",

--- a/validate.py
+++ b/validate.py
@@ -44,11 +44,13 @@ def custom_card_check(args, card, pack_code, factions_data, types_data):
     if card["pack_code"] != pack_code:
         raise jsonschema.ValidationError("Pack code '%s' of the card '%s' doesn't match the pack code '%s' of the file it appears in." % (card["pack_code"], card["code"], pack_code))
     if card.get("faction_code") and card["faction_code"] not in [f["code"] for f in factions_data]:
-        raise jsonschema.ValidationError("Faction code '%s' of the pack '%s' doesn't match any valid faction code." % (card["faction_code"], card["code"]))
-    if card.get("type_code") and  card["type_code"] not in [f["code"] for f in types_data]:
-        raise jsonschema.ValidationError("Faction code '%s' of the pack '%s' doesn't match any valid type code." % (card["type_code"], card["code"]))
+        raise jsonschema.ValidationError("Faction code '%s' of the card '%s' doesn't match any valid faction code." % (card["faction_code"], card["code"]))
+    if card.get("type_code") and card["type_code"] not in [f["code"] for f in types_data]:
+        raise jsonschema.ValidationError("Type code '%s' of the card '%s' doesn't match any valid type code." % (card["type_code"], card["code"]))
     if card.get("traits") and not re.search("[\.!\d]$", card["traits"]):
         raise jsonschema.ValidationError("The traits list \"%s\" on card %s does not end with a period (.), exclamation point (!), or number (0-9)." % (card["traits"], card["code"]))
+    if card.get("type_code") and card["type_code"] == "hero" and not card.get("meta"):
+        raise jsonschema.ValidationError("Hero card '%s' requires the meta property." % (card["code"]))
 
 def format_json(json_data):
     formatted_data = json.dumps(json_data, ensure_ascii=False, sort_keys=True, indent=4, separators=(',', ': '))


### PR DESCRIPTION
After importing heroes and running the full setup locally, I ran into exceptions in the marvelsdb repo because the `meta` field wasn't getting imported into the database for hero cards and the code expects it to be set for all heroes. I updated the code in https://github.com/zzorba/marvelsdb/pull/183 to require that for all hero cards but that means this JSON repo needs to validate and require it also for hero cards.

This PR includes a new check that throws in the validate script if a hero card doesn't have the `meta` field. I verified it by running and seeing that Ant-Man Giant (12001c), Wasp Giant (13001c), and Ironheart V2 (29002a) and V3 (29003a) all didn't have the field so I added the same values for their first hero card to those cards.

I also fixed some typos with the other validate checks.

Once this PR gets merged, we should be able to merge https://github.com/zzorba/marvelsdb/pull/183 without causing problems.