### PR TITLE
Rename Ant-man pack to Ant-Man

### DIFF
--- a/packs.json
+++ b/packs.json
@@ -122,7 +122,7 @@
 		"cgdb_id": 12,
 		"code": "ant",
 		"date_release": "2020-11-06",
-		"name": "Ant-man",
+		"name": "Ant-Man",
 		"octgn_id": "7e399030-8d69-490f-9fd4-dafa6b293a51",
 		"pack_type_code": "hero",
 		"position": 12,

--- a/translations/fr/packs.json
+++ b/translations/fr/packs.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "ant",
-		"name": "Ant-man"
+		"name": "Ant-Man"
 	},
 	{
 		"code": "bkw",

--- a/translations/it/packs.json
+++ b/translations/it/packs.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "ant",
-		"name": "Ant-man"
+		"name": "Ant-Man"
 	},
 	{
 		"code": "bkw",

--- a/translations/ko/packs.json
+++ b/translations/ko/packs.json
@@ -1,7 +1,7 @@
 [
 	{
 		"code": "ant",
-		"name": "Ant-man(앤트맨)"
+		"name": "Ant-Man(앤트맨)"
 	},
 	{
 		"code": "bkw",


### PR DESCRIPTION
The Ant-Man pack is currently named Ant-man so this fixes the name.

For some reason the German translation already had the correct value but the other languages were still using Ant-man as the pack name.