### PR TITLE
Mark Soaring Hearts as a duplicate

### DIFF
--- a/pack/angel.json
+++ b/pack/angel.json
@@ -441,18 +441,10 @@
     },
     {
         "code": "42021",
-        "cost": 2,
-        "deck_limit": 1,
-        "faction_code": "basic",
-        "name": "Soaring Hearts",
-        "octgn_id": "cbfcb70f-a855-4068-b02f-816804042021",
+        "duplicate_of": "41020",
         "pack_code": "angel",
         "position": 21,
-        "quantity": 1,
-        "resource_wild": 1,
-        "text": "Team-Up (Angel and Psylocke). Max 1 per deck.\n<b>Hero Action</b>: Search your discard pile for an identity-specific event and add it to your hand. Ready Angel and Psylocke.",
-        "traits": "Aerial. Psionic.",
-        "type_code": "event"
+        "quantity": 1
     },
     {
         "code": "42022",


### PR DESCRIPTION
Both Psylocke and Angel have the Soaring Hearts Team-Up card.

This PR marks the Angel card (https://marvelcdb.com/card/42021) as a duplicate of the Psylocke card (https://marvelcdb.com/card/41020).