### PR TITLE
Fix the text on Plasma Rifle 40011

### DIFF
--- a/pack/next_evol.json
+++ b/pack/next_evol.json
@@ -234,7 +234,7 @@
         "resource_physical": 1,
         "set_code": "cable",
         "set_position": 13,
-        "text": "Restricted.\n<b>Hero Action</b> <i>(attack)</i>: Exhaust Plasma Rifle and spend a [physical] resource \u2192 deal 1 damage to an enemy for each side scheme in the victory display (to a maximum of 4). This attack gains ranged.",
+        "text": "Restricted.\n<b>Hero Action</b> <i>(attack)</i>: Exhaust Plasma Rifle and spend a [energy] resource \u2192 deal 1 damage to an enemy for each side scheme in the victory display (to a maximum of 4). This attack gains ranged.",
         "traits": "Tech. Weapon.",
         "type_code": "upgrade"
     },


### PR DESCRIPTION
The text on [Plasma Rifle](https://marvelcdb.com/card/40011) had `[physical]` instead of `[energy]` for the resource to spend.

This fixes https://github.com/zzorba/marvelsdb/issues/210.