### PR TITLE
Typo fix on Warlock Cape

### DIFF
--- a/pack/mts.json
+++ b/pack/mts.json
@@ -548,7 +548,7 @@
 		"resource_physical": 1,
 		"set_code": "warlock",
 		"set_position": 4,
-		"text": "<b>Hero Response</b>: After you resolve Adam Warlock's \"Battle Mage\" ability, exhaust Warlock's Cape → ready Adam Warlock's",
+		"text": "<b>Hero Response</b>: After you resolve Adam Warlock's \"Battle Mage\" ability, exhaust Warlock's Cape → ready Adam Warlock.",
 		"traits": "Item.",
 		"type_code": "upgrade"
 	},


### PR DESCRIPTION
From `After you resolve Adam Warlock's "Battle Mage" ability, exhaust Warlock's Cape → ready Adam Warlock's`

to `After you resolve Adam Warlock's "Battle Mage" ability, exhaust Warlock's Cape → ready Adam Warlock.`