### PR TITLE
fix hero for hire trait inconsistency

### DIFF
--- a/pack/core.json
+++ b/pack/core.json
@@ -71,7 +71,7 @@
 		"text": "<b>Forced Response</b>: After you play Black Cat, discard the top 2 cards of your deck. Add each card with a printed [mental] resource discarded this way to your hand.",
 		"thwart": 1,
 		"thwart_cost": 1,
-		"traits": "Hero For Hire.",
+		"traits": "Hero for Hire.",
 		"type_code": "ally"
 	},
 	{


### PR DESCRIPTION
This fix should avoid duplicating the trait "Hero for Hire"

![image](https://github.com/zzorba/marvelsdb-json-data/assets/141938567/c6403c1a-0667-43ff-a55f-697ca2cd6a0c)
