### PR TITLE
[cap] fix-cap-helmet-trait

### DIFF
--- a/pack/cap.json
+++ b/pack/cap.json
@@ -180,7 +180,7 @@
 		"set_code": "captain_america",
 		"set_position": 12,
 		"text": "<b>Interrupt</b>: When Captain America would be defeated, set his hit point dial to 1 instead. Then, discard this card.",
-		"traits": "Item.",
+		"traits": "Armor.",
 		"type_code": "upgrade"
 	},
 	{


### PR DESCRIPTION
Wrong trait for [Captain America's Helmet](https://marvelcdb.com/card/03008)

This should fix https://github.com/zzorba/marvelsdb/issues/233
