### PR TITLE
[core] fix rhino main crisis

### DIFF
--- a/pack/core_encounter.json
+++ b/pack/core_encounter.json
@@ -76,7 +76,6 @@
 		"pack_code": "core",
 		"position": 97,
 		"quantity": 1,
-		"scheme_crisis": 1,
 		"set_code": "rhino",
 		"set_position": 4,
 		"stage": 1,


### PR DESCRIPTION
[The Break-In! - 1B](https://marvelcdb.com/card/01097) shouldn't have a crisis icon

This should fix https://github.com/zzorba/marvelsdb/issues/232