### PR TITLE
[nova] add hidden field on alter-ego

### DIFF
--- a/pack/nova.json
+++ b/pack/nova.json
@@ -34,6 +34,7 @@
 		"faction_code": "hero",
 		"hand_size": 6,
 		"health": 10,
+		"hidden": true,
 		"illustrator": "Joey Vasquez",
 		"is_unique": true,
 		"name": "Sam Alexander",


### PR DESCRIPTION
Nova appears 2 times in the following request, unlikely other heroes

![image](https://github.com/zzorba/marvelsdb-json-data/assets/141938567/7b91a5de-ed45-4b23-a4e5-1ac60fc85b8a)
