### PR TITLE
Fix labeled attack and thwart search

### DIFF
--- a/pack/core.json
+++ b/pack/core.json
@@ -304,7 +304,7 @@
 		"resource_physical": 1,
 		"set_code": "captain_marvel",
 		"set_position": 5,
-		"text": "<b>Hero Action</b> (<i>attack</i>): Deal 5 damage to an enemy. If you paid for this card using a [energy] resource, draw 1 card.",
+		"text": "<b>Hero Action</b> <i>(attack)</i>: Deal 5 damage to an enemy. If you paid for this card using a [energy] resource, draw 1 card.",
 		"traits": "Attack. Superpower.",
 		"type_code": "event"
 	},
@@ -391,7 +391,7 @@
 		"resource_mental": 1,
 		"set_code": "captain_marvel",
 		"set_position": 14,
-		"text": "Max 1 per player.\n<b>Action</b>: Spend X [energy] resources → put X energy counters here.\n<b>Hero Action</b> (<i>attack</i>): Discard Energy Channel → deal 2 damage to an enemy (to a maximum of 10) for each energy counter here.",
+		"text": "Max 1 per player.\n<b>Action</b>: Spend X [energy] resources → put X energy counters here.\n<b>Hero Action</b> <i>(attack)</i>: Discard Energy Channel → deal 2 damage to an enemy (to a maximum of 10) for each energy counter here.",
 		"traits": "Superpower.",
 		"type_code": "upgrade"
 	},
@@ -484,7 +484,7 @@
 		"resource_mental": 1,
 		"set_code": "she_hulk",
 		"set_position": 2,
-		"text": "<b>Hero Action</b> (<i>attack</i>): Deal X damage to an enemy (to a maximum of 15). X is the amount of damage you have sustained.",
+		"text": "<b>Hero Action</b> <i>(attack)</i>: Deal X damage to an enemy (to a maximum of 15). X is the amount of damage you have sustained.",
 		"traits": "Attack. Superpower.",
 		"type_code": "event"
 	},
@@ -699,7 +699,7 @@
 		"resource_physical": 1,
 		"set_code": "iron_man",
 		"set_position": 2,
-		"text": "<b>Hero Action</b> (<i>attack</i>): Deal 1 damage to an enemy and discard the top 5 cards of your deck. For each printed [energy] resource discarded this way, deal 2 additional damage to that enemy.",
+		"text": "<b>Hero Action</b> <i>(attack)</i>: Deal 1 damage to an enemy and discard the top 5 cards of your deck. For each printed [energy] resource discarded this way, deal 2 additional damage to that enemy.",
 		"traits": "Attack. Superpower.",
 		"type_code": "event"
 	},
@@ -717,7 +717,7 @@
 		"resource_energy": 1,
 		"set_code": "iron_man",
 		"set_position": 5,
-		"text": "<b>Hero Action</b> (<i>attack</i>): Deal 4 damage to an enemy (8 damage instead if you have the [[Aerial]] trait).",
+		"text": "<b>Hero Action</b> <i>(attack)</i>: Deal 4 damage to an enemy (8 damage instead if you have the [[Aerial]] trait).",
 		"traits": "Attack.",
 		"type_code": "event"
 	},
@@ -830,7 +830,7 @@
 		"resource_energy": 1,
 		"set_code": "iron_man",
 		"set_position": 12,
-		"text": "<b>Hero Action</b> (<i>attack</i>): Exhaust Powered Gauntlets → deal 1 damage to an enemy (2 damage instead if you have the [[Aerial]] trait).",
+		"text": "<b>Hero Action</b> <i>(attack)</i>: Exhaust Powered Gauntlets → deal 1 damage to an enemy (2 damage instead if you have the [[Aerial]] trait).",
 		"traits": "Armor. Tech.",
 		"type_code": "upgrade"
 	},
@@ -1073,7 +1073,7 @@
 		"resource_energy": 1,
 		"set_code": "black_panther",
 		"set_position": 13,
-		"text": "<b>Special</b> (<i>attack</i>): Deal 2 damage to an enemy (4 damage instead if this is the final step of this sequence).\n<i>(Play the \"Wakanda Forever!\" event to use this ability.)</i>",
+		"text": "<b>Special</b> <i>(attack)</i>: Deal 2 damage to an enemy (4 damage instead if this is the final step of this sequence).\n<i>(Play the \"Wakanda Forever!\" event to use this ability.)</i>",
 		"traits": "Black Panther. Weapon.",
 		"type_code": "upgrade"
 	},
@@ -1107,7 +1107,7 @@
 		"resource_mental": 1,
 		"set_code": "black_panther",
 		"set_position": 15,
-		"text": "<b>Special</b> (<i>attack</i>): Move 1 damage from your hero to an enemy (2 damage instead if this is the final step of this sequence).\n<i>(Play the \"Wakanda Forever!\" event to use this ability.)</i>",
+		"text": "<b>Special</b> <i>(attack)</i>: Move 1 damage from your hero to an enemy (2 damage instead if this is the final step of this sequence).\n<i>(Play the \"Wakanda Forever!\" event to use this ability.)</i>",
 		"traits": "Armor. Black Panther.",
 		"type_code": "upgrade"
 	},
@@ -1182,7 +1182,7 @@
 		"position": 53,
 		"quantity": 3,
 		"resource_energy": 1,
-		"text": "<b>Hero Action</b> (<i>attack</i>): Deal 5 damage to a minion. If you paid for this card using a [physical] resource, this attack gains overkill. <i>(Excess damage from this attack is dealt to the villain.)</i>",
+		"text": "<b>Hero Action</b> <i>(attack)</i>: Deal 5 damage to a minion. If you paid for this card using a [physical] resource, this attack gains overkill. <i>(Excess damage from this attack is dealt to the villain.)</i>",
 		"traits": "Attack.",
 		"type_code": "event"
 	},
@@ -1198,7 +1198,7 @@
 		"position": 54,
 		"quantity": 3,
 		"resource_physical": 1,
-		"text": "<b>Hero Action</b> (<i>attack</i>): Deal 5 damage to an enemy.",
+		"text": "<b>Hero Action</b> <i>(attack)</i>: Deal 5 damage to an enemy.",
 		"traits": "Attack.",
 		"type_code": "event"
 	},
@@ -1594,7 +1594,7 @@
 		"position": 77,
 		"quantity": 3,
 		"resource_physical": 1,
-		"text": "<b>Response</b> (<i>attack</i>): After your hero defends against an enemy attack, deal damage to that enemy equal to your hero's ATK.",
+		"text": "<b>Response</b> <i>(attack)</i>: After your hero defends against an enemy attack, deal damage to that enemy equal to your hero's ATK.",
 		"traits": "Attack.",
 		"type_code": "event"
 	},
@@ -1759,7 +1759,7 @@
 		"position": 87,
 		"quantity": 3,
 		"resource_energy": 1,
-		"text": "<b>Hero Action</b> (<i>attack</i>): Deal 3 damage to an enemy.",
+		"text": "<b>Hero Action</b> <i>(attack)</i>: Deal 3 damage to an enemy.",
 		"traits": "Attack.",
 		"type_code": "event"
 	},

--- a/pack/core.json
+++ b/pack/core.json
@@ -287,7 +287,7 @@
 		"resource_energy": 1,
 		"set_code": "captain_marvel",
 		"set_position": 2,
-		"text": "<b>Hero Action</b> (<i>thwart</i>): Remove 2 threat from a scheme. Then, if you have the [[Aerial]] trait, remove 2 threat from a different scheme.",
+		"text": "<b>Hero Action</b> <i>(thwart)</i>: Remove 2 threat from a scheme. Then, if you have the [[Aerial]] trait, remove 2 threat from a different scheme.",
 		"traits": "Thwart.",
 		"type_code": "event"
 	},
@@ -520,7 +520,7 @@
 		"resource_physical": 1,
 		"set_code": "she_hulk",
 		"set_position": 5,
-		"text": "<b>Alter-Ego Action</b> (<i>thwart</i>): Choose and discard up to 5 cards from your hand → remove 1 threat from a scheme for each card discarded this way.",
+		"text": "<b>Alter-Ego Action</b> <i>(thwart)</i>: Choose and discard up to 5 cards from your hand → remove 1 threat from a scheme for each card discarded this way.",
 		"traits": "Skill. Thwart.",
 		"type_code": "event"
 	},
@@ -573,7 +573,7 @@
 		"resource_physical": 1,
 		"set_code": "she_hulk",
 		"set_position": 11,
-		"text": "<b>Alter-Ego Action</b> (<i>thwart</i>): Exhaust Superhuman Law Division and spend a [mental] resource → remove 2 threat from a scheme.",
+		"text": "<b>Alter-Ego Action</b> <i>(thwart)</i>: Exhaust Superhuman Law Division and spend a [mental] resource → remove 2 threat from a scheme.",
 		"traits": "Location.",
 		"type_code": "support"
 	},
@@ -812,7 +812,7 @@
 		"resource_physical": 1,
 		"set_code": "iron_man",
 		"set_position": 11,
-		"text": "<b>Hero Action</b> (<i>thwart</i>): Exhaust Mark V Helmet → remove 1 threat from a scheme (from each scheme instead if you have the [[Aerial]] trait).",
+		"text": "<b>Hero Action</b> <i>(thwart)</i>: Exhaust Mark V Helmet → remove 1 threat from a scheme (from each scheme instead if you have the [[Aerial]] trait).",
 		"traits": "Armor. Tech.",
 		"type_code": "upgrade"
 	},
@@ -1090,7 +1090,7 @@
 		"resource_physical": 1,
 		"set_code": "black_panther",
 		"set_position": 14,
-		"text": "<b>Special</b> (<i>thwart</i>): Remove 1 threat from a scheme (2 threat instead if this is the final step of this sequence).\n<i>(Play the \"Wakanda Forever!\" event to use this ability.)</i>",
+		"text": "<b>Special</b> <i>(thwart)</i>: Remove 1 threat from a scheme (2 threat instead if this is the final step of this sequence).\n<i>(Play the \"Wakanda Forever!\" event to use this ability.)</i>",
 		"traits": "Black Panther. Skill.",
 		"type_code": "upgrade"
 	},
@@ -1167,7 +1167,7 @@
 		"position": 52,
 		"quantity": 3,
 		"resource_mental": 1,
-		"text": "<b>Response</b> (<i>thwart</i>): After your hero attacks and defeats an enemy, remove 2 threat from a scheme.",
+		"text": "<b>Response</b> <i>(thwart)</i>: After your hero attacks and defeats an enemy, remove 2 threat from a scheme.",
 		"traits": "Thwart.",
 		"type_code": "event"
 	},
@@ -1303,7 +1303,7 @@
 		"position": 60,
 		"quantity": 3,
 		"resource_energy": 1,
-		"text": "<b>Hero Action</b> (<i>thwart</i>): Remove 3 threat from a scheme (4 threat instead if you paid for this card using a [mental] resource).",
+		"text": "<b>Hero Action</b> <i>(thwart)</i>: Remove 3 threat from a scheme (4 threat instead if you paid for this card using a [mental] resource).",
 		"traits": "Thwart.",
 		"type_code": "event"
 	},
@@ -1728,7 +1728,7 @@
 		"position": 85,
 		"quantity": 3,
 		"resource_energy": 1,
-		"text": "<b>Interrupt</b> (<i>thwart</i>): When the villain schemes, reduce the amount of threat placed on the scheme by 1.",
+		"text": "<b>Interrupt</b> <i>(thwart)</i>: When the villain schemes, reduce the amount of threat placed on the scheme by 1.",
 		"traits": "Thwart.",
 		"type_code": "event"
 	},


### PR DESCRIPTION
currently when searching for cards with "(attack)" in text, some results are missing, for example [Powered Gauntlets](https://marvelcdb.com/card/01038)
This should fix the behaviour also for thwart labeled cards

<img src="https://github.com/zzorba/marvelsdb-json-data/assets/141938567/1c3135ad-5696-4397-b32e-564111b64a97" width="500" />

![image](https://github.com/zzorba/marvelsdb-json-data/assets/141938567/d209bb18-de93-44f3-90f0-cd9920075832)
some results are missing, for example [Powered Gauntlets](https://marvelcdb.com/card/01038)

![image](https://github.com/zzorba/marvelsdb-json-data/assets/141938567/89bd7212-94af-4402-be88-94ade74b759c)
