### PR TITLE
[Iceman] fix looking for trouble duplicate

### DIFF
--- a/pack/iceman.json
+++ b/pack/iceman.json
@@ -324,18 +324,10 @@
     },
     {
         "code": "46017",
-        "cost": 0,
-        "deck_limit": 3,
-        "faction_code": "aggression",
-        "name": "Looking for Trouble",
-        "octgn_id": "9612581e-ee76-46fb-89b7-71ae7a046017",
+        "duplicate_of": "16043",
         "pack_code": "iceman",
         "position": 17,
-        "quantity": 3,
-        "resource_physical": 1,
-        "text": "<b>Hero Action</b> <i>(thwart)</i>: Discard cards from the top of the encounter deck until you discard a minion. Put that minion into play engaged with you \u2192 remove 3 threat from the main scheme.",
-        "traits": "Thwart.",
-        "type_code": "event"
+        "quantity": 3
     },
     {
         "base_threat": 2,


### PR DESCRIPTION
Looking for Trouble is displayed twice in the deckbuilding panel

![image](https://github.com/user-attachments/assets/220d7853-c927-401e-996c-62ead7e12fa7)

[Looking for Trouble](https://marvelcdb.com/card/16043)
[Looking for Trouble](https://marvelcdb.com/card/46017)
