### PR TITLE
[MojoMania] Add more detail to Longshot ally

### DIFF
--- a/pack/mojo_encounter.json
+++ b/pack/mojo_encounter.json
@@ -1358,18 +1358,24 @@
 	},
 	{
 		"attack": 2,
+		"attack_cost": 1,
 		"attack_star": true,
 		"code": "39071",
 		"faction_code": "encounter",
 		"health": 3,
+		"is_unique": true,
 		"name": "Longshot",
 		"octgn_id": "56b64e85-e416-4ec5-83e2-4bbd16039071",
 		"pack_code": "mojo",
 		"position": 71,
 		"quantity": 1,
+		"resource_wild": 1,
 		"set_code": "longshot",
 		"set_position": 1,
+		"text": "[star] Longshot's attacks gain piercing.\nLongshot does not count against your ally limit.\n<b>When Revealed:</b> Put Longshot into play under your control. This card gains surge. This effect cannot be canceled.",
+		"traits": "X-Men.",
 		"thwart": 2,
+		"thwart_cost": 1,
 		"type_code": "ally"
 	}
 ]


### PR DESCRIPTION
Adds more detail to the Longshot ally from MojoMania.

For reference:

https://marvelcdb.com/card/39071

![image](https://github.com/user-attachments/assets/ab9893db-72a8-4901-9ca5-f33c6929e86b)
