### PR TITLE
[Nebula] Lethal Intent should have -1 ("X") cost

### DIFF
--- a/pack/nebu.json
+++ b/pack/nebu.json
@@ -204,7 +204,7 @@
 	},
 	{
 		"code": "22010",
-		"cost": 0,
+		"cost": -1,
 		"deck_limit": 3,
 		"faction_code": "hero",
 		"flavor": "\"The Guardians were wise to fear me, and even smarter to hire me on.\" — Nebula",


### PR DESCRIPTION
Lethal Intent should cost "X", which is denoted by `-1`:

> - **cost** - Play cost of the card. Relevant for most cards. Possible values:
>   - -1: Shows up as X
>   - 0+: Shows up as the given integer

For reference:

https://marvelcdb.com/card/22010

![image](https://github.com/user-attachments/assets/9f90d1f0-ba3c-4ae7-b41f-ab92565f17d2)

