### PR TITLE
[Hangar Bay] Add mental resource to Hangar Bay

### DIFF
--- a/pack/storm.json
+++ b/pack/storm.json
@@ -492,6 +492,7 @@
 		"pack_code": "storm",
 		"position": 35,
 		"quantity": 3,
+		"resource_mental": 1,
 		"text": "Max 1 per player.\n<b>Response</b>: After an ally defends against an attack and is not defeated, exhaust this card → ready that ally.",
 		"traits": "Location.",
 		"type_code": "support"


### PR DESCRIPTION
Hangar Bay should have a mental resource.

For reference:

https://marvelcdb.com/card/36035

![image](https://github.com/user-attachments/assets/f0855f14-dc21-418a-83cd-49608de16782)
