### PR TITLE
[Next Evol] fix set types

### DIFF
--- a/sets.json
+++ b/sets.json
@@ -1116,7 +1116,7 @@
 	{
 		"code": "morlock_siege",
 		"name": "Morlock Siege",
-		"card_set_type_code": "modular"
+		"card_set_type_code": "villain"
 	},
 	{
 		"code": "military_grade",
@@ -1131,7 +1131,7 @@
 	{
 		"code": "on_the_run",
 		"name": "On the Run",
-		"card_set_type_code": "modular"
+		"card_set_type_code": "villain"
 	},
 	{
 		"code": "nasty_boys",


### PR DESCRIPTION
[Morlock Siege](https://marvelcdb.com/card/40077) and [On the Run](https://marvelcdb.com/card/40103) are scenarios, not modulars



