### PR TITLE
[trotrs] fix expert campaign set position

### DIFF
--- a/pack/trors.json
+++ b/pack/trors.json
@@ -993,6 +993,7 @@
 		"quantity": 4,
 		"scheme_acceleration": 1,
 		"set_code": "expcamp",
+		"set_position": 1,
 		"text": "<b>Alter-Ego Action</b> Exhaust your alter-ego and spend a [mental] resource → discard this card.",
 		"type_code": "obligation"
 	},
@@ -1007,6 +1008,7 @@
 		"position": 164,
 		"quantity": 4,
 		"set_code": "expcamp",
+		"set_position": 2,
 		"text": "<b>Forced Response:</b> At the end of your turn, take 1 damage if you are in hero form.\n<b>Alter-Ego Action:</b> Discard the top 5 cards of your deck and spend a [physical] resource → discard this card.",
 		"type_code": "obligation"
 	},
@@ -1021,6 +1023,7 @@
 		"position": 165,
 		"quantity": 4,
 		"set_code": "expcamp",
+		"set_position": 3,
 		"text": "Your hand size is reduced by 1.\n<b>Alter-Ego Action:</b> Deal yourself an encounter card and spend a [energy] resource → discard this card.",
 		"type_code": "obligation"
 	},
@@ -1036,6 +1039,7 @@
 		"position": 166,
 		"quantity": 4,
 		"set_code": "expcamp",
+		"set_position": 4,
 		"text": "Your hero gets -1 THW, -1 ATK, and -1 DEF.\n<b>Alter-Ego Action:</b> Take 2 damage and spend a [wild] resource → discard this card.",
 		"type_code": "obligation"
 	}


### PR DESCRIPTION
the set position is not well displayed on expert campaign cards of trotrs:

![image](https://github.com/user-attachments/assets/206ae66d-7caf-48ef-bb93-15bb42514ae0)
