### PR TITLE
[MTS] fix Loki main scheme

### DIFF
--- a/pack/mts_encounter.json
+++ b/pack/mts_encounter.json
@@ -1878,7 +1878,7 @@
 	},
 	{
 		"back_name": "All Hail King Loki",
-		"back_text": "<b> Forced Interrupt: </b> When Loki is defeated, advance to a random set-aside Loki villain. <b> If the number of Lokis in the victory display is equal to the victory condition, the players win the game. (See rule insert.) If this tage is completed, the players loose the game. </b>",
+		"back_text": "<b>Contents</b>: Loki, Infinity Gauntlet, and Standard encounter sets. Two modular encounter sets. <i>(Enchantress and Frost Giants).</i>\n<b>Setup:</b> Set each copy of the Loki villain aside, out of play. Put the War in Asgard side scheme into play. Shuffle the encounter deck. Reveal 1 set-aside Loki villain at random. Reveal the top card of the [[infinity stone]] deck.",
 		"base_threat": 1,
 		"code": "21165",
 		"double_sided": true,
@@ -1892,7 +1892,7 @@
 		"set_code": "loki",
 		"set_position": 6,
 		"stage": 1,
-		"text": "<b> Contents: <b> Loki, infinity Gauntlet, and standard encounter sets. Two modular encounter sets. (Enchantress and Frost Giants).\n<b> Setup: </b> Set each copy of the Loki villain aside, out of play. Put the War in asgard side scheme into play. Shuffle the encounter deck. Reveal 1 set-aside Loki villain at random. Reveal the top card of the [[infinity stone]] deck.",
+		"text": "<b>Forced Interrupt</b>: When Loki is defeated, advance to a random set-aside Loki villain.\n<b> If the number of Lokis in the victory display is equal to the victory condition, the players win the game. (See rule insert.) If this stage is completed, the players lose the game.</b>",
 		"threat": 12,
 		"type_code": "main_scheme"
 	},


### PR DESCRIPTION
should fix https://github.com/zzorba/marvelsdb/issues/254

fix several issues on card [All Hail King Loki - 1A](https://marvelcdb.com/card/21165)

Typo: this tage -> this stage
Typo: players loose the game -> players lose the game
Typo: infinity Gauntlet -> Infinity Gauntlet
Typo: standard -> Standard
Typo: War in asgard -> War in Asgard

fix use of bold and italic tags

move 1A content to the back of card (like [The Break-In! - 1A](https://marvelcdb.com/card/01097))

