### PR TITLE
Fix Magik's Soulsword trait

### DIFF
--- a/pack/aoa.json
+++ b/pack/aoa.json
@@ -547,7 +547,7 @@
         "set_code": "magik",
         "set_position": 4,
         "text": "Restricted.\nMagik's basic attacks gain piercing.\nWhile the top card of your deck has a [physical] or [wild] resource icon, Magik gets +1 ATK.",
-        "traits": "Armor.",
+        "traits": "Weapon.",
         "type_code": "upgrade"
     },
     {


### PR DESCRIPTION
Magik's Soulsword had a trait typo of Armor instead of Weapon.