### PR TITLE
[Vision] Mark Vision's Alter-Ego side as hidden

### DIFF
--- a/pack/vision.json
+++ b/pack/vision.json
@@ -37,6 +37,7 @@
 		"faction_code": "hero",
 		"hand_size": 5,
 		"health": 11,
+		"hidden": true,
 		"illustrator": "Patrick McEvoy",
 		"is_unique": true,
 		"name": "Vision",


### PR DESCRIPTION
All other Alter-Ego cards are marked as `"hidden": true`, except for Vision.

This commit fixes that discrepancy.