### PR TITLE
Face the Past only has 1 copy in Magneto's Precon

### DIFF
--- a/pack/magneto.json
+++ b/pack/magneto.json
@@ -436,7 +436,7 @@
         "octgn_id": "0035c164-5de7-4b2e-bb80-d49e4b049022",
         "pack_code": "magneto",
         "position": 22,
-        "quantity": 3,
+        "quantity": 1,
         "resource_physical": 1,
         "text": "Max 1 per deck.\n<b>Hero Action</b>: Search the encounter deck, discard pile, and set-aside area for your nemesis minion and reveal it \u2192 ready your hero and draw 3 cards. You cannot attack the villain this phase. Remove this card from the game.",
         "type_code": "event"


### PR DESCRIPTION
Noticed this when adding support for Magneto's Hero Pack in DragnCards.