### PR TITLE
There is only 1 copy of Order and Chaos in Scarlet Witch's precon

### DIFF
--- a/pack/scw.json
+++ b/pack/scw.json
@@ -346,7 +346,7 @@
 		"duplicate_of": "14018",
 		"pack_code": "scw",
 		"position": 18,
-		"quantity": 2
+		"quantity": 1
 	},
 	{
 		"code": "15019",


### PR DESCRIPTION
Someone reported this to me when using DragnCards.