### PR TITLE
[AoA] fix type on Apocalypse Solution

### DIFF
--- a/pack/aoa_encounter.json
+++ b/pack/aoa_encounter.json
@@ -1344,7 +1344,7 @@
         "set_code": "apocalypse",
         "set_position": 14,
         "text": "<b>When Defeated</b>: Discard the top X cards of the encounter deck, where X is the numeral in Apocalypse's printed hit point value.",
-        "type_code": "attachment"
+        "type_code": "side_scheme"
     },
     {
         "attack": 2,


### PR DESCRIPTION

fix type on [The Apocalypse Solution](https://marvelcdb.com/card/45111)

![image](https://github.com/user-attachments/assets/ba58198b-5d73-44bc-8294-939bf9b38133)
