### PR TITLE
Fix name of "Thwip Thwip!" to only have one exclamation mark

### DIFF
--- a/pack/spdr.json
+++ b/pack/spdr.json
@@ -348,7 +348,7 @@
 		"deck_limit": 3,
 		"faction_code": "protection",
 		"flavor": "\"You now have the entire afternoon to reconsider your life choices. You're welcome.\" —Spider-Man",
-		"name": "Thwip! Thwip!",
+		"name": "Thwip Thwip!",
 		"octgn_id": "5b7da011-412e-452a-9edd-24618a031017",
 		"pack_code": "spdr",
 		"position": 17,

--- a/translations/it/pack/spdr.json
+++ b/translations/it/pack/spdr.json
@@ -118,7 +118,7 @@
     {
         "code": "31017",
         "flavor": "\"Adesso avrai tutto il pomeriggio per poter riflettere sulle scelte che hai fatto nella vita. Non ringraziarmi.\" — Spider-Man",
-        "name": "Thwip! Thwip!",
+        "name": "Thwip Thwip!",
         "text": "<b>Azione Eroe:</b> Infliggi 1 danno a 1 personaggio [[Web-Warrior]] che controlli → stordisci un totale di 2 volte fino a 2 nemici.",
         "traits": "Superpotere."
     },


### PR DESCRIPTION
The card [Thwip Thwip!](https://marvelcdb.com/card/31017) should only have one exclamation mark in its name:

![image](https://github.com/user-attachments/assets/960bc8c8-2b15-440d-a631-2049778c2fc5)
