### PR TITLE
[GMW][Deadpool] fix weapon typo

### DIFF
--- a/pack/deadpool.json
+++ b/pack/deadpool.json
@@ -213,7 +213,7 @@
         "resource_physical": 1,
         "set_code": "deadpool",
         "set_position": 11,
-        "text": "Restriced.\n<b>Hero Action</b> <i>(attack)</i>: Exhaust Deadpool's Katana and take 1 damage \u2192 deal 2 damage to an enemy. This attack gains piercing.",
+        "text": "Restricted.\n<b>Hero Action</b> <i>(attack)</i>: Exhaust Deadpool's Katana and take 1 damage \u2192 deal 2 damage to an enemy. This attack gains piercing.",
         "traits": "Weapon.",
         "type_code": "upgrade"
     },

--- a/pack/gmw.json
+++ b/pack/gmw.json
@@ -609,7 +609,7 @@
 		"set_code": "rocket",
 		"set_position": 15,
 		"text": "While in hero form, Rocket Raccoon gets +1 THW and gains the [[aerial]] trait.",
-		"traits": "Armor. Weapon.",
+		"traits": "Armor. Tech.",
 		"type_code": "upgrade"
 	},
 	{


### PR DESCRIPTION
fix typo on cards:

[Thruster Boots](https://marvelcdb.com/card/16039)
![image](https://github.com/user-attachments/assets/0ca6e587-ab7b-4b04-b242-9d1c2578bb28)

[Deadpool's Katana](https://marvelcdb.com/card/44010)
![image](https://github.com/user-attachments/assets/c0ca634f-1b25-4653-8624-f470a88d7bca)
