### PR TITLE
Fix typo in Advanced Glider ("rounder" to "round")

### DIFF
--- a/pack/sm_encounter.json
+++ b/pack/sm_encounter.json
@@ -1662,7 +1662,7 @@
 		"scheme_star": true,
 		"set_code": "goblin_gear",
 		"set_position": 1,
-		"text": "Attach to the villain.\n<b>Forced Response</b>: After attached villain activates against you, it activates against you again. (Limit once per rounder per player).\n<b> Hero Action: </b> Discard any number of [[attack]] cards from your hand with a combined resource cost of 3 or more → discard this card.",
+		"text": "Attach to the villain.\n<b>Forced Response</b>: After attached villain activates against you, it activates against you again. (Limit once per round per player).\n<b> Hero Action: </b> Discard any number of [[attack]] cards from your hand with a combined resource cost of 3 or more → discard this card.",
 		"traits": "Item. Tech.",
 		"type_code": "attachment"
 	},


### PR DESCRIPTION
This corrects a typo in the card text of Advanced Glider:
> (Limit once per round~er~ per player).

![advanced_glider](https://github.com/user-attachments/assets/1880d223-9f06-4423-93bf-60d90e6461e7)

