### PR TITLE
[Sinister Motives] fix public outcry hazard icon

### DIFF
--- a/pack/sm.json
+++ b/pack/sm.json
@@ -897,7 +897,7 @@
 		"pack_code": "sm",
 		"position": 174,
 		"quantity": 1,
-		"scheme_acceleration": 1,
+		"scheme_hazard": 1,
 		"set_code": "bad_publicity",
 		"set_position": 1,
 		"traits": "Expert Mode Only.",


### PR DESCRIPTION
fix [Public Outcry](https://marvelcdb.com/card/27174b) icon: hazard instead acceleration
![image](https://github.com/user-attachments/assets/5a479434-7011-4e54-a716-a3aaf6c9b84f)
