### PR TITLE
[Sinister Motives] fix leave-us-alone b side missing stage

### DIFF
--- a/pack/sm_encounter.json
+++ b/pack/sm_encounter.json
@@ -469,6 +469,7 @@
 		"quantity": 1,
 		"set_code": "venom",
 		"set_position": 4,
+		"stage": 1,
 		"text": "<b>Forced Interrupt</b>: When Venom activates against you, move each facedown boost card from your identity to Venom.\n<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 10,
 		"type_code": "main_scheme"


### PR DESCRIPTION
["Leave Us Alone!" - 1A](https://marvelcdb.com/card/27076a)

![image](https://github.com/user-attachments/assets/0f069c70-a1e6-4407-b042-8cc997baef15)