### PR TITLE
[Hood] fix formidable foe missing acceleration icon

### DIFF
--- a/pack/hood_encounter.json
+++ b/pack/hood_encounter.json
@@ -890,10 +890,8 @@
 		"type_code": "treachery"
 	},
 	{
-		"back_name": "Formidable Foe",
-		"back_text": "<b><i>Expert Mode Only.</i></b>\nPermanent. Setup.\nEach enemy gains steady. <i>(Steady characters require 2 status cards of the same type to be stunned or confused.)</i>",
-		"code": "24049",
-		"double_sided": true,
+		"back_link": "24049b",
+		"code": "24049a",
 		"faction_code": "encounter",
 		"name": "Formidable Foe",
 		"octgn_id": "9d1cc110-1771-49b6-807f-c414f8483e6e",
@@ -904,6 +902,22 @@
 		"set_code": "standard_ii",
 		"set_position": 1,
 		"text": "<b><i>Standard Mode Only.</i></b>\nPermanent. Setup.\nThe villain gains steady. <i>(Steady characters require 2 status cards of the same type to be stunned or confused.)</i>",
+		"type_code": "environment"
+	},
+	{
+		"code": "24049b",
+		"faction_code": "encounter",
+		"hidden": true,
+		"name": "Formidable Foe",
+		"octgn_id": "9d1cc110-1771-49b6-807f-c414f8483e6e",
+		"pack_code": "hood",
+		"permanent": true,
+		"position": 49,
+		"quantity": 1,
+		"scheme_acceleration": 1,
+		"set_code": "standard_ii",
+		"set_position": 1,
+		"text": "<b><i>Expert Mode Only.</i></b>\nPermanent. Setup.\nEach enemy gains steady. <i>(Steady characters require 2 status cards of the same type to be stunned or confused.)</i>",
 		"type_code": "environment"
 	},
 	{


### PR DESCRIPTION
[Formidable Foe](https://marvelcdb.com/card/24049)

use back_link method instead double_sided method to add the missing acceleration icon on the B side

![image](https://github.com/user-attachments/assets/75022b8b-7ffa-4379-b9f0-453164fb7405)
