### PR TITLE
fix: X23 endurance, avoid duplicate of duplicate

### DIFF
--- a/pack/x23.json
+++ b/pack/x23.json
@@ -449,7 +449,7 @@
     },
     {
         "code": "43027",
-        "duplicate_of": "36026",
+        "duplicate_of": "05023",
         "pack_code": "x23",
         "position": 27,
         "quantity": 3


### PR DESCRIPTION
Currently X-23 endurance is a duplicate of another duplicate
In marvelsdb, this causes the script php bin/console app:import:std path-to-marvelsdb-json-data/ to fail

This set X-23 endurance as duplicate of the original