### PR TITLE
Add consistency to standard and expert set type

### DIFF
--- a/sets.json
+++ b/sets.json
@@ -657,12 +657,12 @@
 	{
 		"code": "standard_ii",
 		"name": "Standard II",
-		"card_set_type_code": "modular"
+		"card_set_type_code": "standard"
 	},
 	{
 		"code": "expert_ii",
 		"name": "Expert II",
-		"card_set_type_code": "modular"
+		"card_set_type_code": "expert"
 	},
 	{
 		"code": "valk",


### PR DESCRIPTION
Use `"card_set_type_code": "standard"` for each _standard_ set
Use `"card_set_type_code": "expert"` for each _expert_ set