### PR TITLE
Remove useless invocation set type

### DIFF
--- a/settypes.json
+++ b/settypes.json
@@ -22,9 +22,5 @@
 	{
 		"code": "expert",
 		"name": "Expert"
-	},
-	{
-		"code": "invocation",
-		"name": "Invocation"
 	}
 ]


### PR DESCRIPTION

The invocation set type is not used by Doctor Strange's Invocation set:

https://github.com/zzorba/marvelsdb-json-data/blob/3f68323fb5930958d5558f67275c7eac672b0d70/sets.json#L197-L206