### PR TITLE
[TROTRS] fix typo on main scheme

### DIFF
--- a/pack/trors_encounter.json
+++ b/pack/trors_encounter.json
@@ -1624,7 +1624,7 @@
 		"flavor": "Red Skull plans to conquer the world with the power of the Reality Stone. He uses his strategic genius to keep you busy while he works towards his goal.",
 		"hidden": true,
 		"illustrator": "Denis Medri",
-		"name": "The Rise of the Red Skull",
+		"name": "The Rise of Red Skull",
 		"octgn_id": "6f14f5f9-4951-4303-a167-82f2d94f7a80",
 		"pack_code": "trors",
 		"position": 128,


### PR DESCRIPTION

Fix typo on name of the B side on [The Rise of Red Skull - 1B](https://marvelcdb.com/card/04128a)