### PR TITLE
upgrade docs to add docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,10 +191,24 @@ These can be used in a card's `text` section. It will get converted to the appro
 
 #### Translations
 
-To merge new changes in default language in all locales, run the CoffeeScript script `update_locales`.
+To merge new changes in default language in all locales, run the CoffeeScript script `update_locales`. You could install dependency locally or you could use docker.
 
+##### Local installation
 Pre-requisites:
  * `node` and `npm` installed
  * `npm -g install coffee-script`
 
-Usage: `coffee update_locales.coffee`
+Usage: 
+
+`coffee update_locales.coffee`
+
+##### Docker
+Pre-requisites:
+ * [Docker](https://www.docker.com/)
+
+Usage:
+
+```
+docker run -it --rm -v "$PWD":/usr/src/app  -w /usr/src/app node:22 npm install
+docker run -it --rm -v "$PWD":/usr/src/app  -w /usr/src/app node:22 ./node_modules/coffee-script/bin/coffee update_locales.coffee
+```

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
 	"description": "",
 	"main": "index.js",
 	"scripts": {
-	"test": "echo \"Error: no test specified\" && exit 1"
+		"test": "echo \"Error: no test specified\" && exit 1"
 	},
 	"author": "",
 	"license": "ISC",
 	"dependencies": {
-	"lodash": "^4.13.1",
-	"mkdirp": "^0.5.1"
+		"coffee-script": "^1.12.7",
+		"lodash": "^4.13.1",
+		"mkdirp": "^0.5.1"
 	}
 }


### PR DESCRIPTION
**coffescript** is an outdated technology.
This PR add a snippet in order to use docker without the need to install coffescript locally