### PR TITLE
Add "special" set type

### DIFF
--- a/sets.json
+++ b/sets.json
@@ -167,22 +167,22 @@
 	{
 		"code": "piledriver",
 		"name": "Piledriver",
-		"card_set_type_code": "villain"
+		"card_set_type_code": "special"
 	},
 	{
 		"code": "wrecker",
 		"name": "Wrecker",
-		"card_set_type_code": "villain"
+		"card_set_type_code": "special"
 	},
 	{
 		"code": "thunderball",
 		"name": "Thunderball",
-		"card_set_type_code": "villain"
+		"card_set_type_code": "special"
 	},
 	{
 		"code": "bulldozer",
 		"name": "Bulldozer",
-		"card_set_type_code": "villain"
+		"card_set_type_code": "special"
 	},
 	{
 		"code": "black_widow",
@@ -202,7 +202,7 @@
 	{
 		"code": "invocation",
 		"name": "Invocation",
-		"card_set_type_code": "hero"
+		"card_set_type_code": "special"
 	},
 	{
 		"code": "doctor_strange_nemesis",
@@ -312,7 +312,7 @@
 	{
 		"code": "exp_kang",
 		"name": "Expert Kang",
-		"card_set_type_code": "modular"
+		"card_set_type_code": "special"
 	},
 	{
 		"code": "anachronauts",
@@ -997,7 +997,7 @@
 	{
 		"code": "weather",
 		"name": "Weather",
-		"card_set_type_code": "hero"
+		"card_set_type_code": "special"
 	},
 	{
 		"code": "storm_nemesis",
@@ -1112,7 +1112,7 @@
 	{
 		"code": "marauders",
 		"name": "Marauders",
-		"card_set_type_code": "villain"
+		"card_set_type_code": "special"
 	},
 	{
 		"code": "morlock_siege",
@@ -1362,7 +1362,7 @@
 	{
 		"code": "prelates",
 		"name": "Prelates",
-		"card_set_type_code": "modular"
+		"card_set_type_code": "special"
 	},
 	{
 		"code": "iceman",
@@ -1372,7 +1372,7 @@
 	{
 		"code": "frostbite",
 		"name": "Frostbite",
-		"card_set_type_code": "hero"
+		"card_set_type_code": "special"
 	},
 	{
 		"code": "iceman_nemesis",

--- a/settypes.json
+++ b/settypes.json
@@ -20,6 +20,10 @@
 		"name": "Standard"
 	},
 	{
+		"code": "special",
+		"name": "Special"
+	},
+	{
 		"code": "expert",
 		"name": "Expert"
 	},


### PR DESCRIPTION

Prelates are part of the scenario [The Age of Apocalypse - 1A](https://marvelcdb.com/card/45103a)
They can't be used as a regular modular
  
    

For comparison, the set Marauders is also part of both scenario: 
- On the Run [Gotta Get Away - 1A](https://marvelcdb.com/card/40103a)
- Morlock Siege [Knock, Knock - 1A](https://marvelcdb.com/card/40077a)

the set Marauders is designated as "villain" set
https://github.com/zzorba/marvelsdb-json-data/blob/3f68323fb5930958d5558f67275c7eac672b0d70/sets.json#L1112-L1116

