### PR TITLE
[AoA] fix basic campaign name

### DIFF
--- a/sets.json
+++ b/sets.json
@@ -1346,7 +1346,7 @@
 	},
 	{
 		"code": "aoa_basic_campaign",
-		"name": "Campaign",
+		"name": "Basic Campaign",
 		"card_set_type_code": "modular"
 	},
 	{


### PR DESCRIPTION

The name of the set "aoa_basic_campaign" should be changed from "Campaign" into something like "Basic Campaign"

https://marvelcdb.com/set/aoa

![image](https://github.com/user-attachments/assets/f10c8699-1381-41ca-8231-13b21481d92e)

Part of the set "Basic Campaign"
[Blink](https://marvelcdb.com/card/45173)
<img src="https://github.com/user-attachments/assets/0b1340ba-d620-40bb-ae80-e1849b5d65d9" width="200px" />


Part of the set "Campaign"
[Panicked Refugees](https://marvelcdb.com/card/45178)
<img src="https://github.com/user-attachments/assets/7f8beac1-dbb9-44fb-ab37-bdb032c5fca7" width="200px" />
