### PR TITLE
Add card type category

### DIFF
--- a/schema/type_schema.json
+++ b/schema/type_schema.json
@@ -5,6 +5,10 @@
 			"minLength": 1,
 			"type": "string"
 		},
+		"category": {
+			"minLength": 1,
+			"type": "string"
+		},
 		"name": {
 			"minLength": 1,
 			"type": "string"

--- a/types.json
+++ b/types.json
@@ -1,66 +1,82 @@
 [
 	{
 		"code": "main_scheme",
+		"category": "encounter",
 		"name": "Main Scheme"
 	},
 	{
 		"code": "side_scheme",
+		"category": "encounter",
 		"name": "Side Scheme"
 	},
 	{
 		"code": "resource",
+		"category": "player",
 		"name": "Resource"
 	},
 	{
 		"code": "minion",
+		"category": "encounter",
 		"name": "Minion"
 	},
 	{
 		"code": "event",
+		"category": "player",
 		"name": "Event"
 	},
 	{
 		"code": "upgrade",
+		"category": "player",
 		"name": "Upgrade"
 	},
 	{
 		"code": "ally",
+		"category": "player",
 		"name": "Ally"
 	},
 	{
 		"code": "support",
+		"category": "player",
 		"name": "Support"
 	},
 	{
 		"code": "hero",
+		"category": "player",
 		"name": "Hero"
 	},
 	{
 		"code": "alter_ego",
+		"category": "player",
 		"name": "Alter-Ego"
 	},
 	{
 		"code": "villain",
+		"category": "encounter",
 		"name": "Villain"
 	},
 	{
 		"code": "attachment",
+		"category": "encounter",
 		"name": "Attachment"
 	},
 	{
 		"code": "obligation",
+		"category": "encounter",
 		"name": "Obligation"
 	},
 	{
 		"code": "treachery",
+		"category": "encounter",
 		"name": "Treachery"
 	},
 	{
 		"code": "environment",
+		"category": "encounter",
 		"name": "Environment"
 	},
 	{
 		"code": "player_side_scheme",
+		"category": "player",
 		"name": "Player Side Scheme"
 	}
 ]


### PR DESCRIPTION
In order to know if a card is a player card or an encounter card
adding a category of type might be helpful

It implements the definition from [Rules Reference 1.6](https://images-cdn.fantasyflightgames.com/filer_public/da/06/da06051e-1863-44a4-b655-5c8f7929e027/mc_rulesreference_v16_compressed.pdf):

<img src="https://github.com/user-attachments/assets/4551de62-9043-4fac-a69c-37a9327909ba" width="450px"/>

