### PR TITLE
[SPdr] fix missing alter ego

### DIFF
--- a/pack/spdr.json
+++ b/pack/spdr.json
@@ -51,7 +51,6 @@
 		"faction_code": "hero",
 		"hand_size": 4,
 		"health": 14,
-		"hidden": true,
 		"is_unique": true,
 		"name": "Peni Parker",
 		"octgn_id": "5b7da011-412e-452a-9edd-24618a031002",


### PR DESCRIPTION
The card https://marvelcdb.com/card/31002a is currently unreachable

<img src="https://github.com/user-attachments/assets/ece3b3d7-4299-4311-9c37-e1fdb0bfde29" width="500px" />

![image](https://github.com/user-attachments/assets/6017887f-bba8-4722-b25c-65f1eebbe163)

This fix https://github.com/zzorba/marvelsdb/issues/192
