### PR TITLE
Add "cost_per_hero" documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ To check and apply formatting to JSON files:
 * **cost** - Play cost of the card. Relevant for most cards. Possible values:
   * -1: Shows up as X
   * 0+: Shows up as the given integer
+* **cost_per_hero** - Whether the **cost** is per hero
 * **deck_limit** - The max number of the given card that can be in a deck
 * **deck_requirements** - Alter-ego/hero only - describes the character's requirements for an investigator. e.g.:
   ```json

--- a/schema/card_schema.json
+++ b/schema/card_schema.json
@@ -62,6 +62,9 @@
 			"minimum": -1,
 			"type": "integer"
 		},
+		"cost_per_hero": {
+			"type": "boolean"
+		},
 		"deck_limit": {
 			"minimum": 1,
 			"type": "integer"


### PR DESCRIPTION
"cost_per_hero" is already used marvelsdb-json-data, but need documentation.
marvelsdb does not use that field yet.

[Team Investigation](https://marvelcdb.com/card/40053)
![image](https://github.com/user-attachments/assets/f7187a3c-5d85-4b8f-bf24-c7d8afac0dac)

[Break Time](https://marvelcdb.com/card/44046)