### PR TITLE
Use "99" as "X" value

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,21 +55,25 @@ To check and apply formatting to JSON files:
 
 * **attack** - Character's attack value. Format is integer or `null`. Possible values:
   * `null`: Shows up as dash or a star if **attack_star** is defined
-  * -1: Shows up as X
-  * 0+: Shows up as the given integer
+  * `99`: Shows up as X
+  * N: Shows up as the given integer
 * **attack_cost** - Cost for the character to attack (commonly, the amount of consequential damage)
 * **attack_star** - Whether a star appears in the attack field indicating a special ability
 * **back_flavor** - The flavor text on the back of a card (pair with **double_sided**)
 * **back_link** - link to the code of the back side of the card (incompatible with the **double_sided** method). Do not forget to set the back card to **hidden**
 * **back_text** - The text on the back of a card (pair with **double_sided**)
-* **base_threat** - The starting threat on a card. By default, it is per hero.
+* **base_threat** - The starting threat on a card. By default, it is per hero. Possible values:
+  * `null`: Shows up as dash
+  * `99`: Shows up as X
+  * N: Shows up as the given integer
 * **base_threat_fixed** - Whether the **base_threat** is fixed and not per hero
 * **boost** - The number of boost icons on a card
 * **boost_star** - Whether a star appears in the boost field indicating a special ability
 * **code** - 5 digit card identifier. Consists of two zero-padded numbers: first two digits are the cycle position, last three are position of the card within the cycle (printed on the card).
 * **cost** - Play cost of the card. Relevant for most cards. Possible values:
-  * -1: Shows up as X
-  * 0+: Shows up as the given integer
+  * `null`: Shows up as dash
+  * `99`: Shows up as X
+  * N: Shows up as the given integer
 * **deck_limit** - The max number of the given card that can be in a deck
 * **deck_requirements** - Alter-ego/hero only - describes the character's requirements for an investigator. e.g.:
   ```json
@@ -84,8 +88,9 @@ To check and apply formatting to JSON files:
 * **double_sided** - Whether the card is a double sided card (incompatible with the **back_link** method)
 * **duplicate_of** - A link to the original card code for duplicate cards in other packs
 * **escalation_threat** - The acceleration threat to apply to main/side schemes. By default, it is per hero. Possible values:
-  * -1: Shows up as X
-  * 0+: Shows up as the given number
+  * `null`: Shows up as dash or a star if **escalation_threat_star** is defined
+  * `99`: Shows up as X
+  * N: Shows up as the given number
 * **escalation_threat_fixed** - Whether the **escalation_threat** is fixed and not per hero
 * **escalation_threat_star** - Whether a star appears in the escalation threat field indicating a special ability
 * **faction_code** - The faction code type for a card. Possible values:
@@ -115,6 +120,10 @@ To check and apply formatting to JSON files:
 * **recover** - Character's recover value
 * **recover_star** - Whether a star appears in the recover field indicating a special ability
 * **resource_[energy|mental|physical|wild]** - Amount of resources of the given type
+* **scheme** - Character's scheme value. Possible values:
+  * `null`: Shows up as dash or a star if **scheme_star** is defined
+  * `99`: Shows up as X
+  * N: Shows up as the given number
 * **scheme_acceleration** - The acceleration amount on schemes
 * **scheme_crisis** - The number of crisis icons on a scheme
 * **scheme_hazard** - The number of hazard icons on a scheme
@@ -131,8 +140,8 @@ To check and apply formatting to JSON files:
 * **threat_star** - Whether a star appears in the threat field indicating a special ability
 * **thwart** - Character's thwart value. Possible values:
   * `null`: Shows up as dash or a star if **thwart_star** is defined
-  * -1: Shows up as X
-  * 0+: Shows up as the given integer
+  * 99: Shows up as X
+  * N: Shows up as the given integer
 * **thwart_cost** - Cost for the character to thwart (commonly, the amount of consequential damage)
 * **thwart_star** - Whether a star appears in the thwart field indicating a special ability
 * **traits** - List of traits following the pattern `Trait1. Trait2.`

--- a/pack/aoa_encounter.json
+++ b/pack/aoa_encounter.json
@@ -1211,7 +1211,7 @@
         "set_position": 3,
         "stage": 1,
         "text": "X is the numeral in Apocalypse's printed hit point value.\n<b>Forced Interrupt</b>: When Apocalypse would be defeated, discard each attachment from him and heal all damage from him instead. Remove X threat from this scheme <i>(ignoring any crisis ([crisis]) icons)</i>.",
-        "threat": -1,
+        "threat": 99,
         "type_code": "main_scheme"
     },
     {

--- a/pack/core_encounter.json
+++ b/pack/core_encounter.json
@@ -1296,7 +1296,7 @@
 		"type_code": "side_scheme"
 	},
 	{
-		"attack": -1,
+		"attack": 99,
 		"boost": 2,
 		"code": "01162",
 		"faction_code": "encounter",

--- a/pack/gmw_encounter.json
+++ b/pack/gmw_encounter.json
@@ -936,7 +936,7 @@
 	{
 		"base_threat": 2,
 		"code": "16091b",
-		"escalation_threat": -1,
+		"escalation_threat": 99,
 		"faction_code": "encounter",
 		"flavor": "<b><i>You've tracked Nebula's location but she's trying desperately to get away. This may be your only chance to take the Power Stone from her.</i></b>",
 		"hidden": true,
@@ -973,7 +973,7 @@
 	{
 		"base_threat": 3,
 		"code": "16092b",
-		"escalation_threat": -1,
+		"escalation_threat": 99,
 		"faction_code": "encounter",
 		"flavor": "<b><i>Nebula's engines are primed and ready. Take them out before she warp jumps!</i></b>",
 		"hidden": true,

--- a/pack/gob_encounter.json
+++ b/pack/gob_encounter.json
@@ -467,7 +467,7 @@
 	{
 		"base_threat": 4,
 		"code": "02018b",
-		"escalation_threat": -1,
+		"escalation_threat": 99,
 		"escalation_threat_fixed": true,
 		"faction_code": "encounter",
 		"flavor": "The goblin creatures serve Green Goblin's every command. Stop Green Goblin before his monstrous militia overruns the city!",

--- a/pack/ncrawler.json
+++ b/pack/ncrawler.json
@@ -373,7 +373,7 @@
         "type_code": "player_side_scheme"
     },
     {
-        "attack": -1,
+        "attack": 99,
         "attack_cost": 1,
         "code": "48021",
         "cost": 3,
@@ -389,7 +389,7 @@
         "resource_energy": 1,
         "subname": "Remy LeBeau",
         "text": "X is the number of boost icons ([boost]) on the card under Gambit.\n<b>Response</b>: After Gambit enters play, look at the top 3 cards of the encounter deck and tuck one under him so that only the boost field is visible.",
-        "thwart": -1,
+        "thwart": 99,
         "thwart_cost": 1,
         "traits": "Thief. X-Men.",
         "type_code": "ally"

--- a/pack/nebu.json
+++ b/pack/nebu.json
@@ -204,7 +204,7 @@
 	},
 	{
 		"code": "22010",
-		"cost": -1,
+		"cost": 99,
 		"deck_limit": 3,
 		"faction_code": "hero",
 		"flavor": "\"The Guardians were wise to fear me, and even smarter to hire me on.\" — Nebula",

--- a/pack/qsv.json
+++ b/pack/qsv.json
@@ -134,7 +134,7 @@
 	},
 	{
 		"code": "14006",
-		"cost": -1,
+		"cost": 99,
 		"deck_limit": 1,
 		"faction_code": "hero",
 		"flavor": "\"Eat my dust.\" — Quicksilver",

--- a/pack/sm_encounter.json
+++ b/pack/sm_encounter.json
@@ -286,7 +286,7 @@
 		"type_code": "attachment"
 	},
 	{
-		"attack": -1,
+		"attack": 99,
 		"code": "27067",
 		"faction_code": "encounter",
 		"flavor": "\"If you wanna get to me, you gotta go through... ME!\" — Sandman",
@@ -1051,7 +1051,7 @@
 		"type_code": "side_scheme"
 	},
 	{
-		"attack": -1,
+		"attack": 99,
 		"code": "27103",
 		"faction_code": "encounter",
 		"name": "Heightened Morale",

--- a/pack/spdr.json
+++ b/pack/spdr.json
@@ -307,7 +307,7 @@
 		"type_code": "ally"
 	},
 	{
-		"attack": -1,
+		"attack": 99,
 		"attack_cost": 1,
 		"code": "31015",
 		"cost": 3,
@@ -322,7 +322,7 @@
 		"quantity": 1,
 		"resource_energy": 1,
 		"text": "X is equal to the number of facedown cards attached to Spider-Man Noir.\n<b>Response</b>: After you resolve a treachery, if you control another [[Web-Warrior]] card, attach that treachery facedown here (to a maximum of 3).",
-		"thwart": -1,
+		"thwart": 99,
 		"thwart_cost": 1,
 		"traits": "Web-Warrior.",
 		"type_code": "ally"


### PR DESCRIPTION
Currently `-1` has been chosen to describe a "X" value on a card
In order to support negative values, this dev replaces `-1` by `99` on following cards:
[The Age of Apocalypse - 1B](https://marvelcdb.com/card/45103a)
[Titania](https://marvelcdb.com/card/01162)
[The Art of Evasion - 1B](https://marvelcdb.com/card/16091a)
[Warp Drive Initiated - 2B](https://marvelcdb.com/card/16092a)
[Mutagen Cloud - 2B](https://marvelcdb.com/card/02018a)
[Gambit](https://marvelcdb.com/card/48021)
[Lethal Intent](https://marvelcdb.com/card/22010)
[Speed Cyclone](https://marvelcdb.com/card/14006)
[Sand Clone](https://marvelcdb.com/card/27067)
[Heightened Morale](https://marvelcdb.com/card/27103)
[Spider-Man Noir](https://marvelcdb.com/card/31015)

this dev goes along https://github.com/zzorba/marvelsdb/pull/295