### PR TITLE
Fix some traits lacking proper markup

### DIFF
--- a/pack/mts.json
+++ b/pack/mts.json
@@ -308,7 +308,7 @@
 		"position": 15,
 		"quantity": 3,
 		"resource_energy": 1,
-		"text": "Play under any player's control. Max 1 Team per player.\nIf each of your characters has the Avengers trait, each ally you control gets +1 THW and +1 ATK.",
+		"text": "Play under any player's control. Max 1 Team per player.\nIf each of your characters has the [[Avenger]] trait, each ally you control gets +1 THW and +1 ATK.",
 		"traits": "Team.",
 		"type_code": "support"
 	},
@@ -685,7 +685,7 @@
 		"position": 43,
 		"quantity": 1,
 		"resource_physical": 1,
-		"text": "Play only if your identity has the Mystic trait. Max 1 per deck.\n<b>Hero Action</b> <i>(attack)</i>: Choose an enemy and discard up to 5 cards from the top of your deck → deal 1 damage to that enemy for each card discarded this way.",
+		"text": "Play only if your identity has the [[Mystic]] trait. Max 1 per deck.\n<b>Hero Action</b> <i>(attack)</i>: Choose an enemy and discard up to 5 cards from the top of your deck → deal 1 damage to that enemy for each card discarded this way.",
 		"traits": "Attack. Spell.",
 		"type_code": "event"
 	},
@@ -772,7 +772,7 @@
 		"position": 50,
 		"quantity": 1,
 		"resource_mental": 1,
-		"text": "Play only if your identity has the Mystic trait. Max 1 per deck.\n<b>Hero Action</b> <i>(thwart)</i>: Choose a scheme and discard up to 4 cards from the top of your deck → remove 1 threat from that scheme for each card discarded this way.",
+		"text": "Play only if your identity has the [[Mystic]] trait. Max 1 per deck.\n<b>Hero Action</b> <i>(thwart)</i>: Choose a scheme and discard up to 4 cards from the top of your deck → remove 1 threat from that scheme for each card discarded this way.",
 		"traits": "Spell. Thwart.",
 		"type_code": "event"
 	},
@@ -845,7 +845,7 @@
 		"position": 55,
 		"quantity": 1,
 		"resource_mental": 1,
-		"text": "Play only if your identity has the Mystic trait. Max 1 per deck.\n<b>Hero Action</b>: Discard cards from the top of your deck until you discard an ally → put that ally into play under your control.",
+		"text": "Play only if your identity has the [[Mystic]] trait. Max 1 per deck.\n<b>Hero Action</b>: Discard cards from the top of your deck until you discard an ally → put that ally into play under your control.",
 		"traits": "Spell.",
 		"type_code": "event"
 	},
@@ -924,7 +924,7 @@
 		"position": 61,
 		"quantity": 1,
 		"resource_energy": 1,
-		"text": "Play only if your identity has the Mystic trait. Max 1 per deck.\n<b>Hero Interrupt</b> <i>(defense)</i>: When you would take any amount of damage from an attack, discard that many cards from the top of your deck → prevent all damage from this attack.",
+		"text": "Play only if your identity has the [[Mystic]] trait. Max 1 per deck.\n<b>Hero Interrupt</b> <i>(defense)</i>: When you would take any amount of damage from an attack, discard that many cards from the top of your deck → prevent all damage from this attack.",
 		"traits": "Defense. Spell.",
 		"type_code": "event"
 	},
@@ -971,7 +971,7 @@
 		"quantity": 1,
 		"resource_energy": 1,
 		"subname": "T'Naga",
-		"text": "Reduce the cost to play Martinex by 1 if your identity has the Guardian trait.",
+		"text": "Reduce the cost to play Martinex by 1 if your identity has the [[Guardian]] trait.",
 		"thwart": 1,
 		"thwart_cost": 1,
 		"traits": "Guardian.",

--- a/translations/ko/pack/mts.json
+++ b/translations/ko/pack/mts.json
@@ -99,7 +99,7 @@
 	{
 		"code": "21015",
 		"name": "Mighty Avengers",
-		"text": "Play under any player's control. Max 1 Team per player.\nIf each of your characters has the Avengers trait, each ally you control gets +1 THW and +1 ATK.",
+		"text": "Play under any player's control. Max 1 Team per player.\nIf each of your characters has the [[Avenger]] trait, each ally you control gets +1 THW and +1 ATK.",
 		"traits": "Team."
 	},
 	{
@@ -208,7 +208,7 @@
 	{
 		"code": "21043",
 		"name": "Magic Attack",
-		"text": "Play only if your identity has the Mystic trait. Max 1 per deck.\n<b>Hero Action</b> (attack): Choose an enemy and discard up to 5 cards from the top of your deck → deal 1 damage to that enemy for each card discarded this way.",
+		"text": "Play only if your identity has the [[Mystic]] trait. Max 1 per deck.\n<b>Hero Action</b> (attack): Choose an enemy and discard up to 5 cards from the top of your deck → deal 1 damage to that enemy for each card discarded this way.",
 		"traits": "Attack. Spell."
 	},
 	{
@@ -232,7 +232,7 @@
 	{
 		"code": "21050",
 		"name": "Zone of Silence",
-		"text": "Play only if your identity has the Mystic trait. Max 1 per deck.\n<b>Hero Action</b> (thwart): Choose a scheme and discard up to 4 cards from the top of your deck → remove 1 threat from that scheme for each card discarded this way.",
+		"text": "Play only if your identity has the [[Mystic]] trait. Max 1 per deck.\n<b>Hero Action</b> (thwart): Choose a scheme and discard up to 4 cards from the top of your deck → remove 1 threat from that scheme for each card discarded this way.",
 		"traits": "Spell. Thwart."
 	},
 	{
@@ -256,7 +256,7 @@
 	{
 		"code": "21055",
 		"name": "Summoning Spell",
-		"text": "Play only if your identity has the Mystic trait. Max 1 per deck.\n<b>Hero Action</b>: Discard cards from the top of your deck until you discard an ally → put that ally into play under your control.",
+		"text": "Play only if your identity has the [[Mystic]] trait. Max 1 per deck.\n<b>Hero Action</b>: Discard cards from the top of your deck until you discard an ally → put that ally into play under your control.",
 		"traits": "Spell."
 	},
 	{
@@ -279,7 +279,7 @@
 	{
 		"code": "21061",
 		"name": "Shield Spell",
-		"text": "Play only if your identity has the Mystic trait. Max 1 per deck.\n<b>Hero Interrupt</b> (defense): When you would take any amount of damage from an attack, discard that many cards from the top of your deck → prevent all damage from this attack.",
+		"text": "Play only if your identity has the [[Mystic]] trait. Max 1 per deck.\n<b>Hero Interrupt</b> (defense): When you would take any amount of damage from an attack, discard that many cards from the top of your deck → prevent all damage from this attack.",
 		"traits": "Defense. Spell."
 	},
 	{


### PR DESCRIPTION
A few cards in Mad Titan's Shadow were missing the proper `[[trait]]` markup.