### PR TITLE
Add Spider-Man (Peter Parker) ally to Silk pack

### DIFF
--- a/pack/silk.json
+++ b/pack/silk.json
@@ -397,7 +397,7 @@
         "type_code": "ally"
     },
     {
-        "code": "52023",
+        "code": "52022",
         "duplicate_of": "27049",
         "pack_code": "silk",
         "position": 22,

--- a/pack/silk.json
+++ b/pack/silk.json
@@ -398,6 +398,13 @@
     },
     {
         "code": "52023",
+        "duplicate_of": "27049",
+        "pack_code": "silk",
+        "position": 22,
+        "quantity": 1
+    },
+    {
+        "code": "52023",
         "duplicate_of": "27018",
         "pack_code": "silk",
         "position": 23,


### PR DESCRIPTION
The Spider-Man (Peter Parker) ally was missing from Silk's pack.

This video confirms its position in the deck after Madame Web:
https://youtu.be/rOMASbN4OpA?si=ev3QhA4pUmOa6rmk&t=268

![image](https://github.com/user-attachments/assets/a5cc05f4-fa13-4725-9580-d58963f307c1)

The card code for `duplicate_of` is from `sm.json`:
```
{
	"attack": 2,
	"attack_cost": 1,
	"code": "27049",
	"cost": 3,
	"deck_limit": 1,
	"faction_code": "basic",
	"flavor": "\"See, Miles, that's how you do it.\"",
	"health": 3,
	"is_unique": true,
	"name": "Spider-Man",
	"octgn_id": "56ee5f79-c097-4fe0-83b1-f0ef76f7ad17",
	"pack_code": "sm",
	"position": 49,
	"quantity": 1,
	"resource_mental": 1,
	"subname": "Peter Parker",
	"text": "Requirement ([energy] [mental] [physical]). <i>(While paying for this card, spend the listed resources.)</i>\n<b>Response</b>: After Spider-Man attacks or thwarts, choose another [[Web-Warrior]] character → ready that character.",
	"thwart": 2,
	"thwart_cost": 1,
	"traits": "Web-Warrior.",
	"type_code": "ally"
},
```

