### PR TITLE
Add remaining Black Panther and Silk cards to complete the packs

### DIFF
--- a/pack/bp.json
+++ b/pack/bp.json
@@ -485,7 +485,7 @@
         "octgn_id": "4010e194-df1c-477e-852e-3a2adf051025",
         "pack_code": "bp",
         "position": 25,
-        "quantity": 1,
+        "quantity": 2,
         "resource_wild": 1,
         "text": "Team-Up (Black Panther/T'Challa and Black Panther/Shuri). Max 1 per deck.\n<b>Hero Action</b>: Search your deck and discard pile for a [[Black Panther]] upgrade and put it into play. Resolve the \"<b>Special</b>\" ability on up to 4 [[Black Panther]] upgrades you control in any order.",
         "traits": "Wakanda.",
@@ -538,6 +538,7 @@
     {
         "code": "51036",
         "faction_code": "justice",
+        "illustrator": "Denis Medri",
         "name": "Redemption",
         "octgn_id": "4010e194-df1c-477e-852e-3a2adf051036",
         "pack_code": "bp",

--- a/pack/bp_encounter.json
+++ b/pack/bp_encounter.json
@@ -1,5 +1,19 @@
 [
     {
+        "boost": 2,
+        "code": "51031",
+        "faction_code": "encounter",
+        "illustrator": "Facundo Moyano",
+        "name": "T'Challa's Shadow",
+        "octgn_id": "4010e194-df1c-477e-852e-3a2adf051031",
+        "pack_code": "bp",
+        "position": 31,
+        "quantity": 1,
+        "set_code": "black_panther_shuri",
+        "text": "<b><i>Give to the Shuri player.</i></b>\nUses (4 doubt counters). Victory 0.\nIncrease the resource cost of each card you play by 1.\n<b>Forced Response</b>: After you thwart, attack, or defend, remove 1 doubt counter from here.",
+        "type_code": "obligation"
+    },
+    {
         "attack": 0,
         "attack_star": true,
         "boost": 3,
@@ -60,6 +74,20 @@
         "type_code": "minion"
     },
     {
+        "boost_star": true,
+        "code": "51035",
+        "faction_code": "encounter",
+        "name": "The Scream",
+        "octgn_id": "4010e194-df1c-477e-852e-3a2adf051035",
+        "pack_code": "bp",
+        "position": 35,
+        "quantity": 2,
+        "set_code": "black_panther_shuri_nemesis",
+        "set_position": 4,
+        "text": "<b>When Revealed</b>: Stun each character you control. Deal 1 damage to each of those characters that was already stunned.\n<hr />\n[star] <b>Boost</b>: You are stunned. If you were already stunned, take 1 damage.",
+        "type_code": "treachery"
+    },
+    {
         "attack": 1,
         "attack_star": true,
         "boost": 4,
@@ -80,6 +108,23 @@
         "text": "Villainous. Victory 1.\n[star] <b>Forced Interrupt</b>: When Joystick activates against you, choose:\n\u2022 Give her 1 additional boost card for this activation and draw 1 card.\n\u2022 Give her a tough status card.",
         "traits": "Elite. Thunderbolt.",
         "type_code": "minion"
+    },
+    {
+        "attack": 1,
+        "attack_star": true,
+        "boost": 2,
+        "code": "51040",
+        "faction_code": "encounter",
+        "illustrator": "Facundo Moyano",
+        "name": "Energy Truncheon",
+        "octgn_id": "4010e194-df1c-477e-852e-3a2adf051040",
+        "pack_code": "bp",
+        "position": 40,
+        "quantity": 2,
+        "set_code": "extreme_risk",
+        "set_position": 2,
+        "text": "Attach to Joystick. Otherwise, attach to the villain.\n[star] Attached enemy's attacks gain piercing.\n<b>Hero Action</b>: Attached enemy attacks you. After this attack, discard this card and draw 1 card.",
+        "type_code": "attachment"
     },
     {
         "base_threat": 3,
@@ -106,7 +151,7 @@
         "octgn_id": "4010e194-df1c-477e-852e-3a2adf051042",
         "pack_code": "bp",
         "position": 42,
-        "quantity": 1,
+        "quantity": 2,
         "set_code": "extreme_risk",
         "set_position": 5,
         "text": "<b>When Revealed</b>: Find Joystick and reveal her. <i>(If she is already in play, she engages you.)</i> Joystick activates against you. If no enemy  activated this way, this card gains surge.\n<hr />\n[star] <b>Boost</b>: You may give the activating enemy an additional boost card. If you do, draw 1 card.",

--- a/pack/bp_encounter.json
+++ b/pack/bp_encounter.json
@@ -124,6 +124,7 @@
         "set_code": "extreme_risk",
         "set_position": 2,
         "text": "Attach to Joystick. Otherwise, attach to the villain.\n[star] Attached enemy's attacks gain piercing.\n<b>Hero Action</b>: Attached enemy attacks you. After this attack, discard this card and draw 1 card.",
+        "traits": "Tech. Weapon.",
         "type_code": "attachment"
     },
     {

--- a/pack/silk.json
+++ b/pack/silk.json
@@ -397,6 +397,13 @@
         "type_code": "ally"
     },
     {
+        "code": "52022",
+        "duplicate_of": "27049",
+        "pack_code": "silk",
+        "position": 22,
+        "quantity": 1
+    },
+    {
         "code": "52023",
         "duplicate_of": "27018",
         "pack_code": "silk",

--- a/pack/silk_encounter.json
+++ b/pack/silk_encounter.json
@@ -1,5 +1,19 @@
 [
     {
+        "boost": 2,
+        "code": "52028",
+        "faction_code": "encounter",
+        "illustrator": "Allie Preswick",
+        "name": "Silk Sense Overload",
+        "octgn_id": "25cf07ae-e8ab-4443-8040-672bd2052028",
+        "pack_code": "silk",
+        "position": 28,
+        "quantity": 1,
+        "set_code": "silk",
+        "text": "<b><i>Give to the Cindy Moon player.</i></b>\n<b>Forced Interrupt</b>: When a card would be tucked under your identity by a player card effect, tuck it under here instead. Then, if there are 2 tucked cards here, you may discard this card (remove it from the game instead if there are 3 or more tucked cards here).",
+        "type_code": "obligation"
+    },
+    {
         "attack": 1,
         "attack_star": true,
         "boost": 3,
@@ -101,10 +115,25 @@
         "octgn_id": "25cf07ae-e8ab-4443-8040-672bd2052037",
         "pack_code": "silk",
         "position": 37,
-        "quantity": 1,
+        "quantity": 2,
         "set_code": "growing_strong",
-        "set_position": 4,
+        "set_position": 3,
         "text": "<b>When Revealed</b>: Find Atlas and reveal him. <i>(If he is already in play, he engages you.)</i> Atlas activates against you. If no enemy activated this way, this card gains surge.\n<hr />\n[star] <b>Boost</b>: Give the activating enemy a tough status card.",
+        "type_code": "treachery"
+    },
+    {
+        "boost": 1,
+        "boost_star": true,
+        "code": "52038",
+        "faction_code": "encounter",
+        "name": "Titanic Proportions",
+        "octgn_id": "25cf07ae-e8ab-4443-8040-672bd2052038",
+        "pack_code": "silk",
+        "position": 38,
+        "quantity": 2,
+        "set_code": "growing_strong",
+        "set_position": 5,
+        "text": "<b>When Revealed</b>: The players as a group take X indirect damage, where X is the number of growth counters on Atlas. If X is less than 3, this card gains surge.\n<hr />\n[star] <b>Boost</b>: If Atlas is in play, place 1 growth counter on him.",
         "type_code": "treachery"
     }
 ]

--- a/packs.json
+++ b/packs.json
@@ -508,7 +508,7 @@
 		"position": 50,
 		"size": 273
 	},
-  	{
+	{
 		"cgdb_id": 51,
 		"code": "bp",
 		"date_release": "2025-04-18",
@@ -518,7 +518,7 @@
 		"position": 51,
 		"size": 60
 	},
-  	{
+	{
 		"cgdb_id": 52,
 		"code": "silk",
 		"date_release": "2025-04-18",
@@ -527,5 +527,5 @@
 		"pack_type_code": "hero",
 		"position": 52,
 		"size": 60
-  	}
+	}
 ]


### PR DESCRIPTION
This adds the remaining Black Panther and Silk cards that weren't spoiled by the time the previous two PRs (https://github.com/zzorba/marvelsdb-json-data/pull/592 and https://github.com/zzorba/marvelsdb-json-data/pull/603) were merged.

This adds the following cards:
* 51031
* 51035
* 51040
* 52022
* 52028
* 52038

It also fixes some quantities that were not entirely known at the time the previous PRs were created.