### PR TITLE
Fix issues with In a Bind 18027

### DIFF
--- a/pack/gam_encounter.json
+++ b/pack/gam_encounter.json
@@ -54,15 +54,14 @@
 		"boost": 1,
 		"code": "18027",
 		"faction_code": "encounter",
-		"name": "In A Bind",
+		"name": "In a Bind",
 		"octgn_id": "1558fbcd-a85d-4798-bacc-ae85ae505344",
 		"pack_code": "gam",
 		"position": 27,
 		"quantity": 1,
 		"set_code": "gam_nemesis",
 		"set_position": 3,
-		"text": "Attach to Gamora.\nTreat Gamora's printed text box as if it were blank <i>(except for [[traits]])</i>.\n<b>Hero Action: </b>Choose and discard an [[attack]] event from your hand and deal 1 damage to Gamora → discard this card.",
-		"traits": "Armor. Tech.",
+		"text": "Attach to Gamora.\nTreat Gamora's printed text box as if it were blank <i>(except for [[traits]])</i>.\n<b>Hero Action</b>: Choose and discard an [[attack]] event from your hand and deal 1 damage to Gamora → discard this card.",
 		"type_code": "attachment"
 	},
 	{


### PR DESCRIPTION
This fixes several issues related to In a Bind (18027).
* The title was `In A Bind` instead of `In a Bind`
* The card incorrectly included traits
* The colon next to `Hero Action` as incorrectly bolded

This should fix https://github.com/zzorba/marvelsdb/issues/307.