### PR TITLE
Fix cards that have the "cards gains" typo

### DIFF
--- a/pack/hood_encounter.json
+++ b/pack/hood_encounter.json
@@ -776,7 +776,7 @@
 		"scheme_acceleration": 1,
 		"set_code": "sinister_syndicate",
 		"set_position": 1,
-		"text": "<b>When Revealed:</b> Search the encounter deck for a [[Criminal]] minion and put it into play engaged with you. <i>(Shuffle.)</i> If no minion was put into play this way, this cards gains surge.",
+		"text": "<b>When Revealed</b>: Search the encounter deck for a [[Criminal]] minion and put it into play engaged with you. <i>(Shuffle.)</i> If no minion was put into play this way, this card gains surge.",
 		"type_code": "side_scheme"
 	},
 	{

--- a/pack/spiderham_encounter.json
+++ b/pack/spiderham_encounter.json
@@ -9,7 +9,7 @@
 		"position": 24,
 		"quantity": 1,
 		"set_code": "spiderham",
-		"text": "<b>Give to the Peter Porker player.</b>\nYou may flip to alter-ego form. Choose:\n\u2022 Exhaust Peter Porker and remove 1 toon counter from him → remove \"I Really Want a Hot Dog\" from the game.\n\u2022 You are stunned. If you are already stunned, this cards gains surge. Discard this obligation.",
+		"text": "<b>Give to the Peter Porker player.</b>\nYou may flip to alter-ego form. Choose:\n\u2022 Exhaust Peter Porker and remove 1 toon counter from him → remove \"I Really Want a Hot Dog!\" from the game.\n\u2022 You are stunned. If you are already stunned, this card gains surge. Discard this obligation.",
 		"type_code": "obligation"
 	},
 	{


### PR DESCRIPTION
This fixes two cards (24042 and 30024) which had `this cards gains surge` instead of `this card gains surge` typos

This fixes https://github.com/zzorba/marvelsdb/issues/311