### PR TITLE
Fix some mistakes from the Falcon and Winter Soldier packs

### DIFF
--- a/pack/falcon.json
+++ b/pack/falcon.json
@@ -458,7 +458,6 @@
     {
         "code": "53034",
         "cost": 1,
-        "deck_limit": 1,
         "faction_code": "leadership",
         "flavor": "\"This shield is a symbol of freedom.\" \u2014Captain America",
         "is_unique": true,

--- a/pack/winter.json
+++ b/pack/winter.json
@@ -474,7 +474,7 @@
         "quantity": 3,
         "resource_mental": 1,
         "text": "Play only if your identity has the [[S.H.I.E.L.D.]] trait.\nAttach to a friendly character.\nAttached character gets +1 hit point and gains the [[S.H.I.E.L.D.]] trait.",
-        "traits": "Weapon.",
+        "traits": "Title.",
         "type_code": "upgrade"
     }
 ]


### PR DESCRIPTION
There were a couple mistakes on the recent Falcon and Winter Soldier packs

* [53034](https://marvelcdb.com/card/53034) is a Linked card so it should not be allowed in decks
* [54033](https://marvelcdb.com/card/54033) had the Weapon trait instead of Title


Fixes https://github.com/zzorba/marvelsdb/issues/324
Fixes https://github.com/zzorba/marvelsdb/issues/325