### PR TITLE
Fix capitalisation of "Team-Up" on some cards

### DIFF
--- a/pack/ant.json
+++ b/pack/ant.json
@@ -416,7 +416,7 @@
 		"position": 20,
 		"quantity": 1,
 		"resource_mental": 1,
-		"text": "Team-up (Ant-Man and Wasp). Max 1 per deck.\n<b>Hero Action:</b> Change to your other hero form. Ready your hero.",
+		"text": "Team-Up (Ant-Man and Wasp). Max 1 per deck.\n<b>Hero Action:</b> Change to your other hero form. Ready your hero.",
 		"traits": "Tactic.",
 		"type_code": "event"
 	},

--- a/pack/winter.json
+++ b/pack/winter.json
@@ -399,7 +399,7 @@
         "position": 22,
         "quantity": 2,
         "resource_physical": 1,
-        "text": "Team-up (Captain America and Winter Soldier). Max 1 per deck.\n<b>Hero Action</b> <i>(attack)</i>: Deal 6 damage to an enemy. Give Captain America and Winter Soldier each a tough status card.",
+        "text": "Team-Up (Captain America and Winter Soldier). Max 1 per deck.\n<b>Hero Action</b> <i>(attack)</i>: Deal 6 damage to an enemy. Give Captain America and Winter Soldier each a tough status card.",
         "traits": "Attack.",
         "type_code": "event"
     },
@@ -414,7 +414,7 @@
         "position": 23,
         "quantity": 2,
         "resource_energy": 1,
-        "text": "Team-up (Black Widow and Winter Soldier). Max 1 per deck.\n<b>Hero Action</b> <i>(attack)</i>: Put a [[Preparation]] upgrade from your discard pile into play. Deal 4 damage to an enemy.",
+        "text": "Team-Up (Black Widow and Winter Soldier). Max 1 per deck.\n<b>Hero Action</b> <i>(attack)</i>: Put a [[Preparation]] upgrade from your discard pile into play. Deal 4 damage to an enemy.",
         "traits": "Attack.",
         "type_code": "event"
     },

--- a/translations/it/pack/ant.json
+++ b/translations/it/pack/ant.json
@@ -164,7 +164,7 @@
 		"flavor": "",
 		"name": "Tattica dello Sciame",
 		"subname": "",
-		"text": "Team-up (Ant-Man e Wasp). Massimo 1 per mazzo.\n<b>Azione Eroe:</b> Assumi la tua altra sembianza di eroe. Ripristina il tuo eroe.",
+		"text": "Team-Up (Ant-Man e Wasp). Massimo 1 per mazzo.\n<b>Azione Eroe:</b> Assumi la tua altra sembianza di eroe. Ripristina il tuo eroe.",
 		"traits": "Tattica."
 	},
 	{


### PR DESCRIPTION
A few Team-Up cards had inconsitent capitalisation ("Team-up").

The correct capitalisation is "Team-Up":

![image](https://github.com/user-attachments/assets/620e1fcd-be91-4b64-ba9e-eb759ec1a7e8)
