### PR TITLE
Change the stage property to a string and fix incorrect values

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,7 @@ To check and apply formatting to JSON files:
 * **scheme_star** - Whether a star appears in the scheme field indicating a special ability
 * **set_code** - The code for the card's set. Possible values found in `sets.json`.
 * **set_position** - The position of the card in the set
-* **stage** - The stage number on a villain or main scheme. Possible values:
-  * `null`: There is no stage for the villain or main scheme
-  * 0+: Shows up as the given integer
+* **stage** - The stage of the villain or main scheme
 * **subname** - Subname associated with a character (e.g. `Carol Danvers` is a subname for `Captain Marvel`)
 * **text** - The text on a card
 * **threat** - The target threat on a card before it advances. By default, it is per hero.

--- a/pack/aoa_encounter.json
+++ b/pack/aoa_encounter.json
@@ -215,7 +215,7 @@
         "scheme": 1,
         "set_code": "unus",
         "set_position": 1,
-        "stage": 1,
+        "stage": "I",
         "text": "Toughness.\nIf the amount of threat on Gene Pool is at least:\n\u2022 3 \u2014 Unus gains retaliate 1.\n\u2022 6 \u2014 Unus also gains stalwart.\n\u2022 9 \u2014 Unus also gains a [amplify] icon.",
         "traits": "Prelate.",
         "type_code": "villain"
@@ -236,7 +236,7 @@
         "scheme": 2,
         "set_code": "unus",
         "set_position": 2,
-        "stage": 2,
+        "stage": "II",
         "text": "Toughness.\nIf the amount of threat on Gene Pool is at least:\n\u2022 3 \u2014 Unus gains retaliate 1.\n\u2022 6 \u2014 Unus also gains stalwart.\n\u2022 9 \u2014 Unus also gains a [amplify] icon.",
         "traits": "Prelate.",
         "type_code": "villain"
@@ -257,7 +257,7 @@
         "scheme": 2,
         "set_code": "unus",
         "set_position": 3,
-        "stage": 3,
+        "stage": "III",
         "text": "Toughness.\nIf the amount of threat on Gene Pool is at least:\n\u2022 3 \u2014 Unus gains retaliate 1.\n\u2022 6 \u2014 Unus also gains stalwart.\n\u2022 9 \u2014 Unus also gains a [amplify] icon.",
         "traits": "Prelate.",
         "type_code": "villain"
@@ -274,7 +274,7 @@
         "quantity": 1,
         "set_code": "unus",
         "set_position": 4,
-        "stage": 1,
+        "stage": "1A",
         "text": "<b>Contents</b>: Unus (I) and Unus (II). <i>(Unus (II) and Unus (III) instead for expert mode.)</i> Unus, Infinites, and Standard sets. One modular set <i>(Dystopian Nightmare)</i>.\n<b>Setup</b>: Reveal the Gene Pool side scheme. In expert mode, deal each player a facedown encounter card.",
         "type_code": "main_scheme"
     },
@@ -295,7 +295,7 @@
         "quantity": 1,
         "set_code": "unus",
         "set_position": 4,
-        "stage": 1,
+        "stage": "1B",
         "text": "[star] <b>Forced Response</b>: After resolving step one of the villain phase, place 1 threat on Gene Pool.\n<b>If this scheme is completed, the players lose the game.</b>",
         "threat": 11,
         "type_code": "main_scheme"
@@ -630,6 +630,7 @@
         "scheme": 1,
         "set_code": "four_horsemen",
         "set_position": 1,
+        "stage": "A",
         "text": "[star] <b>Forced Response</b>: After War attacks you, if he has at least 1 hit point, discard an upgrade or support you control.\n<b>War cannot be defeated while another villain has at least 1 hit point.</b>",
         "traits": "Horsemen.",
         "type_code": "villain"
@@ -652,6 +653,7 @@
         "scheme": 2,
         "set_code": "four_horsemen",
         "set_position": 1,
+        "stage": "B",
         "text": "[star] <b>Forced Response</b>: After War attacks you, if he has at least 1 hit point, discard an upgrade or support you control.\n<b>War cannot be defeated while another villain has at least 1 hit point.</b>",
         "traits": "Horsemen.",
         "type_code": "villain"
@@ -674,6 +676,7 @@
         "scheme": 2,
         "set_code": "four_horsemen",
         "set_position": 2,
+        "stage": "A",
         "text": "[star] <b>Forced Response</b>: After Famine attacks you, if she has at least 1 hit point, discard the top 10 cards of your deck.\n<b>Famine cannot be defeated while another villain has at least 1 hit point.</b>",
         "traits": "Horsemen.",
         "type_code": "villain"
@@ -696,6 +699,7 @@
         "scheme": 3,
         "set_code": "four_horsemen",
         "set_position": 2,
+        "stage": "B",
         "text": "[star] <b>Forced Response</b>: After Famine attacks you, if she has at least 1 hit point, discard the top 10 cards of your deck.\n<b>Famine cannot be defeated while another villain has at least 1 hit point.</b>",
         "traits": "Horsemen.",
         "type_code": "villain"
@@ -718,6 +722,7 @@
         "scheme": 2,
         "set_code": "four_horsemen",
         "set_position": 3,
+        "stage": "A",
         "text": "[star] <b>Forced Response</b>: After Pestilence attacks you, if she has at least 1 hit point, treat your identity's text box as if it were blank <i>(except for [[Traits]])</i> until the next villain phase begins.\n<b>Pestilence cannot be defeated while another villain has at least 1 hit point.</b>",
         "traits": "Horsemen.",
         "type_code": "villain"
@@ -740,6 +745,7 @@
         "scheme": 3,
         "set_code": "four_horsemen",
         "set_position": 3,
+        "stage": "B",
         "text": "[star] <b>Forced Response</b>: After Pestilence attacks you, if she has at least 1 hit point, treat your identity's text box as if it were blank <i>(except for [[Traits]])</i> until the next villain phase begins.\n<b>Pestilence cannot be defeated while another villain has at least 1 hit point.</b>",
         "traits": "Horsemen.",
         "type_code": "villain"
@@ -762,6 +768,7 @@
         "scheme": 1,
         "set_code": "four_horsemen",
         "set_position": 4,
+        "stage": "A",
         "text": "[star] <b>Forced Response</b>: After Death attacks you, if he has at least 1 hit point, deal 1 damage to each character you control.\n<b>Death cannot be defeated while another villain has at least 1 hit point.</b>",
         "traits": "Aerial. Horsemen.",
         "type_code": "villain"
@@ -784,6 +791,7 @@
         "scheme": 2,
         "set_code": "four_horsemen",
         "set_position": 4,
+        "stage": "B",
         "text": "[star] <b>Forced Response</b>: After Death attacks you, if he has at least 1 hit point, deal 1 damage to each character you control.\n<b>Death cannot be defeated while another villain has at least 1 hit point.</b>",
         "traits": "Aerial. Horsemen.",
         "type_code": "villain"
@@ -800,7 +808,7 @@
         "quantity": 1,
         "set_code": "four_horsemen",
         "set_position": 5,
-        "stage": 1,
+        "stage": "1A",
         "text": "<b>Contents</b>: War (A), Famine (A), Pestilence (A), Death (A), Four Horsemen, Standard, and two modular sets <i>(Dystopian Nightmare and Hounds)</i>.\n<b>Setup</b>: Shuffle the four [[Horsemen]] villains, then reveal them in a row from left to right. Place the active counter on the leftmost villain (see rulebook). Each player reveals a random side scheme from the Four Horsemen encounter set.",
         "type_code": "main_scheme"
     },
@@ -820,7 +828,7 @@
         "quantity": 1,
         "set_code": "four_horsemen",
         "set_position": 5,
-        "stage": 1,
+        "stage": "1B",
         "text": "<b>Forced Response</b>: After a villain activates, move the active counter to the next villain.\n<b>If this stage is completed, the players lose the game.</b>",
         "threat": 12,
         "type_code": "main_scheme"
@@ -1103,7 +1111,7 @@
         "scheme": 1,
         "set_code": "apocalypse",
         "set_position": 1,
-        "stage": 1,
+        "stage": "I",
         "text": "Toughness.\n<b>Forced Interrupt</b>: When the main scheme is completed, remove all threat from it <i>(ignoring any crisis ([crisis]) icons)</i>. Flip this card and reveal Apocalypse (II).",
         "traits": "Mutant.",
         "type_code": "villain"
@@ -1126,7 +1134,7 @@
         "scheme": 2,
         "set_code": "apocalypse",
         "set_position": 1,
-        "stage": 2,
+        "stage": "II",
         "text": "Steady. Toughness.\n<b>Forced Interrupt</b>: When the main scheme is completed, remove all threat from it <i>(ignoring any crisis ([crisis]) icons)</i>. Remove this card from the game and reveal Apocalypse (III).",
         "traits": "Mutant.",
         "type_code": "villain"
@@ -1149,7 +1157,7 @@
         "scheme": 2,
         "set_code": "apocalypse",
         "set_position": 2,
-        "stage": 3,
+        "stage": "III",
         "text": "Steady. Toughness.\n<b>Forced Interrupt</b>: When the main scheme is completed, remove all threat from it <i>(ignoring any crisis ([crisis]) icons)</i>. Flip this card and reveal Apocalypse (IV).",
         "traits": "Mutant.",
         "type_code": "villain"
@@ -1173,7 +1181,7 @@
         "scheme": 3,
         "set_code": "apocalypse",
         "set_position": 2,
-        "stage": 4,
+        "stage": "IV",
         "text": "Stalwart. Toughness.\n[star] Apocalypse's attacks gain overkill.\n<b>Forced Interrupt</b>: When the main scheme is completed, the players lose the game.",
         "traits": "Mutant.",
         "type_code": "villain"
@@ -1190,7 +1198,7 @@
         "quantity": 1,
         "set_code": "apocalypse",
         "set_position": 3,
-        "stage": 1,
+        "stage": "1A",
         "text": "<b>Contents</b>: Apocalypse (II) and Apocalypse (III). <i>(Apocalypse (III) only for expert mode.)</i> Apocalypse, Prelates, and Standard sets. Two modular sets <i>(Dark Riders and Infinites)</i>.\n<b>Setup</b>: Set aside each unused villain card, each [[Prelate]] minion, and The Tyrant's Throne side scheme. Reveal the Heart of the Empire side scheme. The first player reveals a random, set-aside [[Prelate]] minion.",
         "type_code": "main_scheme"
     },
@@ -1209,7 +1217,7 @@
         "quantity": 1,
         "set_code": "apocalypse",
         "set_position": 3,
-        "stage": 1,
+        "stage": "1B",
         "text": "X is the numeral in Apocalypse's printed hit point value.\n<b>Forced Interrupt</b>: When Apocalypse would be defeated, discard each attachment from him and heal all damage from him instead. Remove X threat from this scheme <i>(ignoring any crisis ([crisis]) icons)</i>.",
         "threat": -1,
         "type_code": "main_scheme"
@@ -1529,7 +1537,7 @@
         "scheme": 2,
         "set_code": "dark_beast",
         "set_position": 1,
-        "stage": 1,
+        "stage": "I",
         "text": "[star] <b>Forced Interrupt</b>: When Dark Beast attacks you, resolve the \"<b>Special</b>\" ability on the [[Setting]] environment.\n<b>When Revealed</b>: Reveal a random set-aside environment and shuffle the rest of its encounter set into the encounter deck.",
         "traits": "Brute. Genius.",
         "type_code": "villain"
@@ -1551,7 +1559,7 @@
         "scheme": 2,
         "set_code": "dark_beast",
         "set_position": 2,
-        "stage": 2,
+        "stage": "II",
         "text": "[star] <b>Forced Interrupt</b>: When Dark Beast attacks you, resolve the \"<b>Special</b>\" ability on the [[Setting]] environment.\n<b>When Revealed</b>: Reveal a random set-aside environment and shuffle the rest of its encounter set into the encounter deck. Deal each player an encounter card.",
         "traits": "Brute. Genius.",
         "type_code": "villain"
@@ -1573,7 +1581,7 @@
         "scheme": 3,
         "set_code": "dark_beast",
         "set_position": 3,
-        "stage": 3,
+        "stage": "III",
         "text": "[star] <b>Forced Interrupt</b>: When Dark Beast attacks you, resolve the \"<b>Special</b>\" ability on the [[Setting]] environment.\n<b>When Revealed</b>: Reveal a random set-aside environment and shuffle the rest of its encounter set into the encounter deck. Deal each player an encounter card.",
         "traits": "Brute. Genius.",
         "type_code": "villain"
@@ -1590,7 +1598,7 @@
         "quantity": 1,
         "set_code": "dark_beast",
         "set_position": 4,
-        "stage": 1,
+        "stage": "1A",
         "text": "<b>Contents</b>: Dark Beast (I) and Dark Beast (II). <i>(Dark Beast (II) and Dark Beast (III) for expert mode.)</i> Dark Beast, Blue Moon, Genosha, Savage Land, and Standard sets. One modular set <i>(Dystopian Nightmare)</i>.\n<b>Setup</b>: Set the Blue Moon, Genosha, and Savage Land sets aside <i>(including each environment card in those sets)</i>. In expert mode, reveal the High-Tech Goggles attachment.",
         "type_code": "main_scheme"
     },
@@ -1609,7 +1617,7 @@
         "quantity": 1,
         "set_code": "dark_beast",
         "set_position": 4,
-        "stage": 1,
+        "stage": "1B",
         "text": "<b>If this stage is completed, the players lose the game.</b>",
         "threat": 10,
         "type_code": "main_scheme"
@@ -2078,7 +2086,7 @@
         "quantity": 1,
         "set_code": "en_sabah_nur",
         "set_position": 4,
-        "stage": 1,
+        "stage": "1A",
         "text": "<b>Contents</b>: Apocalypse (I) and Apocalypse (II). <i>(Apocalypse (II) and Apocalypse (III) for expert mode.)</i> En Sabah Nur and Standard sets. Two modular sets <i>(Celestial Tech and Clan Akkaba)</i>.\n<b>Setup</b>: Apocalypse begins the game in [[Biomorph]] form. Deal each player a facedown encounter card.",
         "type_code": "main_scheme"
     },
@@ -2098,7 +2106,7 @@
         "quantity": 1,
         "set_code": "en_sabah_nur",
         "set_position": 4,
-        "stage": 1,
+        "stage": "1B",
         "text": "[star] <b>Forced Response</b>: After resolving step 1 of the villain phase, place 1 power counter here. If there are at least 4 power counters here, the first player removes 4 of them and discards cards from the top of the encounter deck until a [[Superpower]] card is discarded and reveal it.",
         "threat": 8,
         "type_code": "main_scheme"
@@ -2116,7 +2124,7 @@
         "quantity": 1,
         "set_code": "en_sabah_nur",
         "set_position": 5,
-        "stage": 2,
+        "stage": "2A",
         "text": "<b>When Revealed</b>: The first player discards cards from the top of the encounter deck until a [[Superpower]] card is discarded and reveals it.",
         "type_code": "main_scheme"
     },
@@ -2135,7 +2143,7 @@
         "quantity": 1,
         "set_code": "en_sabah_nur",
         "set_position": 5,
-        "stage": 2,
+        "stage": "2B",
         "text": "[star] <b>Forced Response</b>: After resolving step 1 of the villain phase, place 1 power counter here. If there are at least 4 power counters here, the first player removes 4 of them and discards cards from the top of the encounter deck until a [[Superpower]] card is discarded and reveals it.\n<b>If this scheme is completed, the players lose the game.</b>",
         "threat": 10,
         "type_code": "main_scheme"
@@ -2868,7 +2876,7 @@
         "scheme": 1,
         "set_code": "en_sabah_nur",
         "set_position": 1,
-        "stage": 1,
+        "stage": "I",
         "text": "[star] Apocalypse's attacks gain overkill.\n<b>Forced Response</b>: After Apocalypse changes to this form, deal 1 indirect damage to each player.",
         "traits": "Mutant. Biomorph.",
         "type_code": "villain"
@@ -2891,7 +2899,7 @@
         "scheme": 2,
         "set_code": "en_sabah_nur",
         "set_position": 1,
-        "stage": 1,
+        "stage": "I",
         "text": "Retaliate 1.\n<b>Forced Response</b>: After Apocalypse changes to this form, place 1 threat on each scheme in play.",
         "traits": "Mutant. Cyberpath.",
         "type_code": "villain"
@@ -2913,7 +2921,7 @@
         "scheme": 2,
         "set_code": "en_sabah_nur",
         "set_position": 1,
-        "stage": 1,
+        "stage": "I",
         "text": "Stalwart.\n<b>Forced Response</b>: After Apocalypse changes to this form, heal 1 damage from him.",
         "traits": "Mutant. Giant.",
         "type_code": "villain"
@@ -2937,7 +2945,7 @@
         "scheme": 1,
         "set_code": "en_sabah_nur",
         "set_position": 2,
-        "stage": 2,
+        "stage": "II",
         "text": "[star] Apocalypse's attacks gain overkill.\n<b>Forced Response</b>: After Apocalypse changes to this form, deal 2 indirect damage to each player.",
         "traits": "Mutant. Biomorph.",
         "type_code": "villain"
@@ -2960,7 +2968,7 @@
         "scheme": 3,
         "set_code": "en_sabah_nur",
         "set_position": 2,
-        "stage": 2,
+        "stage": "II",
         "text": "Retaliate 1.\n<b>Forced Response</b>: After Apocalypse changes to this form, place 2 threat on each scheme in play.",
         "traits": "Mutant. Cyberpath.",
         "type_code": "villain"
@@ -2982,7 +2990,7 @@
         "scheme": 2,
         "set_code": "en_sabah_nur",
         "set_position": 2,
-        "stage": 2,
+        "stage": "II",
         "text": "Stalwart.\n<b>Forced Response</b>: After Apocalypse changes to this form, heal 2 damage from him.",
         "traits": "Mutant. Giant.",
         "type_code": "villain"
@@ -3006,7 +3014,7 @@
         "scheme": 2,
         "set_code": "en_sabah_nur",
         "set_position": 3,
-        "stage": 3,
+        "stage": "III",
         "text": "[star] Apocalypse's attacks gain overkill.\n<b>Forced Response</b>: After Apocalypse changes to this form, deal 3 indirect damage to each player.",
         "traits": "Mutant. Biomorph.",
         "type_code": "villain"
@@ -3029,7 +3037,7 @@
         "scheme": 3,
         "set_code": "en_sabah_nur",
         "set_position": 3,
-        "stage": 3,
+        "stage": "III",
         "text": "Retaliate 1.\n<b>Forced Response</b>: After Apocalypse changes to this form, place 3 threat on each scheme in play.",
         "traits": "Mutant. Cyberpath.",
         "type_code": "villain"
@@ -3051,7 +3059,7 @@
         "scheme": 3,
         "set_code": "en_sabah_nur",
         "set_position": 3,
-        "stage": 3,
+        "stage": "III",
         "text": "Stalwart.\n<b>Forced Response</b>: After Apocalypse changes to this form, heal 3 damage from him.",
         "traits": "Mutant. Giant.",
         "type_code": "villain"

--- a/pack/aos_encounter.json
+++ b/pack/aos_encounter.json
@@ -177,7 +177,7 @@
         "scheme": 2,
         "set_code": "black_widow_villain",
         "set_position": 1,
-        "stage": 1,
+        "stage": "I",
         "text": "<b>Forced Interrupt</b>: When a character you control attacks Black Widow, remove 1 threat from the main scheme <i>(ignoring any crisis icons in play)</i> \u2192 discard the top card of the encounter deck and resolve each \"<b>Preparation</b>\" ability on that card.",
         "traits": "Spy.",
         "type_code": "villain"
@@ -198,7 +198,7 @@
         "scheme": 2,
         "set_code": "black_widow_villain",
         "set_position": 2,
-        "stage": 2,
+        "stage": "II",
         "text": "<b>When Revealed</b>: Place 2[per_hero] threat on the main scheme.\n<b>Forced Interrupt</b>: When a character you control attacks Black Widow, remove 1 threat from the main scheme \u2192 discard the top card of the encounter deck and resolve each \"<b>Preparation</b>\" ability on that card.",
         "traits": "Spy.",
         "type_code": "villain"
@@ -219,7 +219,7 @@
         "scheme": 3,
         "set_code": "black_widow_villain",
         "set_position": 3,
-        "stage": 3,
+        "stage": "III",
         "text": "<b>When Revealed</b>: Place 3[per_hero] threat on the main scheme.\n<b>Forced Interrupt</b>: When a character you control attacks Black Widow, remove 1 threat from the main scheme \u2192 discard the top card of the encounter deck and resolve each \"<b>Preparation</b>\" ability on that card.",
         "traits": "Spy.",
         "type_code": "villain"
@@ -236,7 +236,7 @@
         "quantity": 1,
         "set_code": "black_widow_villain",
         "set_position": 4,
-        "stage": 1,
+        "stage": "1A",
         "text": "<b>Contents</b>: Black Widow (I) and Black Widow (II). <i>(Black Widow (II) and Black Widow (III) instead for expert mode.)</i> Black Widow and Standard encounter sets. Two modular encounter sets <i>(A.I.M. Abduction and A.I.M. Science)</i>.\n<b>Setup</b>: Each player searches the encounter deck for a minion and puts it into play engaged with them. <i>(Shuffle.)</i>",
         "type_code": "main_scheme"
     },
@@ -255,7 +255,7 @@
         "quantity": 1,
         "set_code": "black_widow_villain",
         "set_position": 4,
-        "stage": 1,
+        "stage": "1B",
         "text": "X is Black Widow's stage number.\n<b>If this stage is completed, the players lose the game.</b>",
         "threat": 10,
         "type_code": "main_scheme"
@@ -580,6 +580,7 @@
         "scheme": 1,
         "set_code": "batroc",
         "set_position": 1,
+        "stage": "A",
         "text": "[star] <b>Forced Response</b>: After Batroc attacks, place 1 threat on Alert Level.\n<b>Forced Interrupt</b>: When Batroc would be defeated, reset his hit points to 8 instead. Then, remove 6 threat from the main scheme.",
         "traits": "Batroc's Brigade. Mercenary.",
         "type_code": "villain"
@@ -601,6 +602,7 @@
         "scheme": 2,
         "set_code": "batroc",
         "set_position": 1,
+        "stage": "B",
         "text": "[star] <b>Forced Response</b>: After Batroc attacks, place 1 threat on Alert Level.\n<b>Forced Interrupt</b>: When Batroc would be defeated, reset his hit points to 12 instead. Then, remove 6 threat from the main scheme.",
         "traits": "Batroc's Brigade. Mercenary.",
         "type_code": "villain"
@@ -617,7 +619,7 @@
         "quantity": 1,
         "set_code": "batroc",
         "set_position": 2,
-        "stage": 1,
+        "stage": "1A",
         "text": "<b>Contents</b>: Batroc (A). <i>(Batroc (B) instead for expert mode.)</i> Batroc and Standard encounter sets. Two modular encounter sets <i>(A.I.M. Science and Batrocs's Brigade)</i>.\n<b>Setup</b>: Set each Rescued Captive ally aside. Put the Alert Level environment into play, [[Low]] side faceup. In expert mode, place 2[per_hero] threat on Alert Level.",
         "type_code": "main_scheme"
     },
@@ -636,7 +638,7 @@
         "quantity": 1,
         "set_code": "batroc",
         "set_position": 2,
-        "stage": 1,
+        "stage": "1B",
         "text": "<b>Forced Interrupt</b>: When the last threat is removed from this scheme, advance to stage 2A <i>(the players win by advancing)</i>.\n<b>If this stage is completed, the players lose the game.</b>",
         "threat": 12,
         "type_code": "main_scheme"
@@ -653,7 +655,7 @@
         "quantity": 1,
         "set_code": "batroc",
         "set_position": 3,
-        "stage": 2,
+        "stage": "2A",
         "type_code": "main_scheme"
     },
     {
@@ -669,7 +671,7 @@
         "quantity": 1,
         "set_code": "batroc",
         "set_position": 3,
-        "stage": 2,
+        "stage": "2B",
         "text": "<b>Forced Interrupt</b>: When the last threat is removed from this scheme, put 1 set-aside Rescued Captive ally into play exhausted under any player's control. The players may advance to stage 3A. If they do not advance, place 3[per_hero] threat here. <i>(The players win by advancing, but will need at least 1 Rescued Captive to survive.)</i>\n<b>If this stage is completed, the players lose the game.</b>",
         "threat": 10,
         "type_code": "main_scheme"
@@ -687,7 +689,7 @@
         "quantity": 1,
         "set_code": "batroc",
         "set_position": 4,
-        "stage": 3,
+        "stage": "3A",
         "text": "<b>When Revealed</b>: If the Alert Level is on its [[High]] side, deal each player 1 facedown encounter card. Otherwise, remove all threat from Alert Level and flip it to its [[High]] side. In either case, in expert mode, place 2[per_hero] threat on Alert Level.",
         "type_code": "main_scheme"
     },
@@ -705,7 +707,7 @@
         "quantity": 1,
         "set_code": "batroc",
         "set_position": 4,
-        "stage": 3,
+        "stage": "3B",
         "text": "In expert mode, each minion gains quickstrike.\n<b>Forced Interrupt</b>: When an enemy attacks, it attacks a Rescued Captive instead.\n<b>If there is no threat here, the players win the game.</b>\n<b>If this stage is completed or there are no Rescued Captive allies in play, the players lose the game.</b>",
         "threat": 18,
         "type_code": "main_scheme"
@@ -970,6 +972,7 @@
         "scheme": 2,
         "set_code": "m.o.d.o.k.",
         "set_position": 1,
+        "stage": "A",
         "text": "Retaliate 1.\n<b>Forced Interrupt</b>: When M.O.D.O.K. would be defeated, if a Holding Cell is in play, remove 2 lock counters from it and reset M.O.D.O.K.'s hit points to 10 instead. Otherwise, <b>the players win the game</b>.",
         "traits": "Aerial. Cyborg. Psionic.",
         "type_code": "villain"
@@ -990,6 +993,7 @@
         "scheme": 3,
         "set_code": "m.o.d.o.k.",
         "set_position": 1,
+        "stage": "B",
         "text": "Retaliate 2. Steady.\n<b>Forced Interrupt</b>: When M.O.D.O.K. would be defeated, if a Holding Cell is in play, remove 2 lock counters from it and reset M.O.D.O.K.'s hit points to 14 instead. Otherwise, <b>the players win the game</b>.",
         "traits": "Aerial. Cyborg. Psionic.",
         "type_code": "villain"
@@ -1006,7 +1010,7 @@
         "quantity": 1,
         "set_code": "m.o.d.o.k.",
         "set_position": 2,
-        "stage": 1,
+        "stage": "1A",
         "text": "<b>Contents</b>: M.O.D.O.K. (A). <i>(M.O.D.O.K. (B) instead for expert mode.)</i> M.O.D.O.K. and Standard encounter sets. One modular encounter set <i>(Scientist Supreme)</i>.\n<b>Setup</b>: Create the Holding Cell deck <i>(see rulebook p. 13)</i>. Put 1 random [[Adaptoid]] environment into play (2 environments instead in expert mode) and set the others aside. Each player searches the encounter deck for a copy of Adaptoid and reveals it.",
         "type_code": "main_scheme"
     },
@@ -1024,7 +1028,7 @@
         "quantity": 1,
         "set_code": "m.o.d.o.k.",
         "set_position": 2,
-        "stage": 1,
+        "stage": "1B",
         "text": "<b>Forced Interrupt</b>: When this stage would be completed, put 1 random set-aside [[Adaptoid]] environment into play instead. Then, <b>if there are no set-aside [[Adaptoid]] environments, the players lose the game</b>. Otherwise, remove all threat from here and shuffle each Adaptoid minion from the encounter discard pile into the encounter deck.",
         "threat": 7,
         "type_code": "main_scheme"
@@ -1544,6 +1548,7 @@
         "scheme_star": true,
         "set_code": "thunderbolts",
         "set_position": 1,
+        "stage": "A",
         "text": "Citizen V cannot be defeated unless there are at least 1[per_hero] [[Thunderbolt]] minions in the victory display.\n[star] <b>Forced Interrupt</b>: When Citizen V would activate against you during step two of the villain phase, if you are engaged with a [[Thunderbolt]] minion, Citizen V does not activate and heals 4 damage instead.",
         "traits": "Thunderbolt.",
         "type_code": "villain"
@@ -1567,6 +1572,7 @@
         "scheme_star": true,
         "set_code": "thunderbolts",
         "set_position": 1,
+        "stage": "B",
         "text": "Citizen V cannot be defeated unless there are at least 1[per_hero] [[Thunderbolt]] minions in the victory display.\n[star] <b>Forced Interrupt</b>: When Citizen V would activate against you during step two of the villain phase, if you are engaged with a [[Thunderbolt]] minion, Citizen V does not activate and heals 6 damage instead.",
         "traits": "Thunderbolt.",
         "type_code": "villain"
@@ -1583,7 +1589,7 @@
         "quantity": 1,
         "set_code": "thunderbolts",
         "set_position": 2,
-        "stage": 1,
+        "stage": "1A",
         "text": "<b>Contents</b>: Citizen V (A). <i>(Citizen V (B) instead for expert mode.)</i> Thunderbolts and Standard encounter sets.\n<b>Setup</b>: Choose 1 modular set, plus 1[per_hero] additional modular sets, each with an [[Elite]], [[Thunderbolt]] minion. Set each of those minions aside and shuffle the rest of their encounter sets into the encounter deck. Reveal the Justice, Like Lightning environment.",
         "type_code": "main_scheme"
     },
@@ -1602,7 +1608,7 @@
         "quantity": 1,
         "set_code": "thunderbolts",
         "set_position": 2,
-        "stage": 1,
+        "stage": "1B",
         "text": "Each [[Thunderbolt]] minion gains guard.\n<b>Forced Response</b>: After a player attacks a [[Thunderbolt]] minion, that minion engages that player.\n<b>If this stage is completed, the players lose the game.</b>",
         "threat": 11,
         "type_code": "main_scheme"
@@ -2230,7 +2236,7 @@
         "scheme": 3,
         "set_code": "baron_zemo",
         "set_position": 1,
-        "stage": 1,
+        "stage": "A1",
         "text": "<b>Forced Interrupt</b>: When Baron Zemo would be defeated, reset his hit points to 12 instead. Remove 3 secret counters from among [[Board Member]] environments.",
         "traits": "Thunderbolt.",
         "type_code": "villain"
@@ -2254,7 +2260,7 @@
         "scheme_star": true,
         "set_code": "baron_zemo",
         "set_position": 1,
-        "stage": 2,
+        "stage": "A2",
         "text": "[star] <b>Forced Interrupt</b>: When Baron Zemo activates against you, either place 1 secret counter on a [[Board Member]] card or give Baron Zemo an additional boost card for this activation.",
         "traits": "Thunderbolt. Unmasked.",
         "type_code": "villain"
@@ -2276,7 +2282,7 @@
         "scheme": 4,
         "set_code": "baron_zemo",
         "set_position": 2,
-        "stage": 1,
+        "stage": "B1",
         "text": "<b>Forced Interrupt</b>: When Baron Zemo would be defeated, reset his hit points to 16 instead. Remove 3 secret counters from among [[Board Member]] environments.",
         "traits": "Thunderbolt.",
         "type_code": "villain"
@@ -2300,7 +2306,7 @@
         "scheme_star": true,
         "set_code": "baron_zemo",
         "set_position": 2,
-        "stage": 2,
+        "stage": "B2",
         "text": "Steady.\n[star] <b>Forced Interrupt</b>: When Baron Zemo activates against you, either place 2 secret counters on a [[Board Member]] card or give Baron Zemo an additional boost card for this activation.",
         "traits": "Thunderbolt. Unmasked.",
         "type_code": "villain"
@@ -2317,7 +2323,7 @@
         "quantity": 1,
         "set_code": "baron_zemo",
         "set_position": 3,
-        "stage": 1,
+        "stage": "1A",
         "text": "<b>Contents</b>: Baron Zemo (A1). <i>(Baron Zemo (B1) instead for expert mode.)</i> Baron Zemo, S.H.I.E.L.D. Executive Board, Executive Board Evidence, and Standard encounter sets. Two modular encounter sets <i>(Scientist Supreme and S.H.I.E.L.D.)</i>.\n<b>Setup</b>: Prepare the evidence <i>(see rulebook p. 18)</i>. Put each [[Board Member]] environment into play. If not playing campaign mode, place 2 secret counters on each [[Board Member]] environment.",
         "type_code": "main_scheme"
     },
@@ -2335,7 +2341,7 @@
         "quantity": 1,
         "set_code": "baron_zemo",
         "set_position": 3,
-        "stage": 1,
+        "stage": "1B",
         "text": "<b>Response</b>: After the player phase ends, the first player may place 2 secret counters on a [[Board Member]] environment that has no secret counters on it to gain 2 cards from the S.H.I.E.L.D. envelope (1 card instead in campaign mode). The players may advance to stage 2A to make their accusation.\n<b>If this stage is completed, the players lose the game.</b>",
         "threat": 12,
         "type_code": "main_scheme"
@@ -2353,7 +2359,7 @@
         "quantity": 1,
         "set_code": "baron_zemo",
         "set_position": 4,
-        "stage": 2,
+        "stage": "2A",
         "text": "<b>When Revealed</b>: Make an accusation by guessing a means, a motive, and an opportunity, along with the board member associated with that combination in the campaign log. This board member is the accused. <i>(See \"The Accusation\" on p. 19 of the rulebook.)</i>",
         "type_code": "main_scheme"
     },
@@ -2369,7 +2375,7 @@
         "quantity": 1,
         "set_code": "baron_zemo",
         "set_position": 4,
-        "stage": 2,
+        "stage": "2B",
         "text": "<b>When Revealed</b>: Do the following:\n1. Use the cards in the A.I.M. envelope to identify the mole.\n2. For each guess you got wrong, place 1 secret counter on each [[Board Member]] card.\n3. If you accused the wrong board member, place 3 secret counters on the accused.\n4. Advance to stage 3A.",
         "type_code": "main_scheme"
     },
@@ -2385,7 +2391,7 @@
         "quantity": 1,
         "set_code": "baron_zemo",
         "set_position": 5,
-        "stage": 3,
+        "stage": "3A",
         "text": "<b>When Revealed</b>: Flip Baron Zemo to his [[Unmasked]] side and reset his hit points to his printed hit point value. Find Baron Zemo's Sword and attach it to him.",
         "type_code": "main_scheme"
     },
@@ -2404,7 +2410,7 @@
         "quantity": 1,
         "set_code": "baron_zemo",
         "set_position": 5,
-        "stage": 3,
+        "stage": "3B",
         "text": "<b>When Revealed</b>: Flip the mole to its attachment side and attach it to Baron Zemo. Place 1[per_hero] threat here for each secret counter on each [[Board Member]] attachment.\n<b>If this stage is completed, the players lose the game.</b>",
         "threat": 12,
         "type_code": "main_scheme"

--- a/pack/core_encounter.json
+++ b/pack/core_encounter.json
@@ -15,7 +15,7 @@
 		"scheme": 1,
 		"set_code": "rhino",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"traits": "Brute. Criminal.",
 		"type_code": "villain"
 	},
@@ -35,7 +35,7 @@
 		"scheme": 1,
 		"set_code": "rhino",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "II",
 		"text": "<b>When Revealed</b>: Search the encounter deck and discard pile for the Breakin' & Takin' side scheme and reveal it. Shuffle the encounter deck.",
 		"traits": "Brute. Criminal.",
 		"type_code": "villain"
@@ -56,7 +56,7 @@
 		"scheme": 1,
 		"set_code": "rhino",
 		"set_position": 3,
-		"stage": 3,
+		"stage": "III",
 		"text": "Toughness. <i>(This character enter play with a tough status card.)</i>\n<b>When Revealed</b>: Stun each hero.",
 		"traits": "Brute. Criminal.",
 		"type_code": "villain"
@@ -73,7 +73,7 @@
 		"quantity": 1,
 		"set_code": "rhino",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1A",
 		"text": "<b>Contents</b>: Rhino (I) and Rhino (II). (Rhino (II) and Rhino (III) instead for expert mode.) Rhino and Standard encounter sets. One modular encounter set <i>(recommended: Bomb Scare)</i>.\n<b>Setup</b>: Advance to stage 1B.",
 		"type_code": "main_scheme"
 	},
@@ -92,7 +92,7 @@
 		"quantity": 1,
 		"set_code": "rhino",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1B",
 		"text": "<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 7,
 		"type_code": "main_scheme"
@@ -362,7 +362,7 @@
 		"scheme": 2,
 		"set_code": "klaw",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "[star] <b>Forced Interrupt</b>: When Klaw attacks, give him 1 additional boost card for this activation.",
 		"traits": "Masters of Evil.",
 		"type_code": "villain"
@@ -383,7 +383,7 @@
 		"scheme": 2,
 		"set_code": "klaw",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "II",
 		"text": "<b>When Revealed</b>: Search the encounter deck and discard pile for The \"Immortal\" Klaw and reveal it. Shuffle the encounter deck.\n[star] <b>Forced Interrupt</b>: When Klaw attacks, give him 1 additional boost card for this activation.",
 		"traits": "Masters of Evil.",
 		"type_code": "villain"
@@ -404,7 +404,7 @@
 		"scheme": 3,
 		"set_code": "klaw",
 		"set_position": 3,
-		"stage": 3,
+		"stage": "III",
 		"text": "Toughness. <i>(This character enters play with a tough status card.)</i>\n[star] <b>Forced Interrupt</b>: When Klaw attacks, give him 1 additional boost card for this activation.",
 		"traits": "Masters of Evil.",
 		"type_code": "villain"
@@ -421,7 +421,7 @@
 		"quantity": 1,
 		"set_code": "klaw",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1A",
 		"text": "<b>Contents</b>: Klaw (I) and Klaw (II). <i>(Klaw (II) and Klaw (III) instead for expert mode.)</i> Klaw and Standard encounter sets. One modular encounter set <i>(recommended: Masters of Evil)</i>\n<b>Setup</b>: Search the encounter deck for the Defense Network side scheme and reveal it. Shuffle the encounter deck. Advance to stage 1B.",
 		"type_code": "main_scheme"
 	},
@@ -440,7 +440,7 @@
 		"quantity": 1,
 		"set_code": "klaw",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1B",
 		"text": "<b>When Revealed</b>: Discard cards from the encounter deck until a minion is discarded. Put that minion into play engaged with the first player.",
 		"threat": 6,
 		"type_code": "main_scheme"
@@ -457,7 +457,7 @@
 		"quantity": 1,
 		"set_code": "klaw",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2A",
 		"text": "<b>When Revealed</b>: Discard cards from the encounter deck until a minion is discarded. Put that minion into play engaged with the first player. Advance to stage 2B",
 		"type_code": "main_scheme"
 	},
@@ -476,7 +476,7 @@
 		"quantity": 1,
 		"set_code": "klaw",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2B",
 		"text": "<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 8,
 		"type_code": "main_scheme"
@@ -771,7 +771,7 @@
 		"scheme": 1,
 		"set_code": "ultron",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "[star] <b>Forced Response</b>: After Ultron attacks you, choose to either place 1 threat on the main scheme or put the top card of your deck into play facedown, engaged with you as a [[Drone]] minion.",
 		"traits": "Android.",
 		"type_code": "villain"
@@ -792,7 +792,7 @@
 		"scheme": 2,
 		"set_code": "ultron",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "II",
 		"text": "[star] <b>Forced Interrupt</b>: When Ultron attacks you, put the top card of your deck into play facedown, engaged with you as a [[Drone]] minion. Until the end of his attack, Ultron gets +1 ATK for each [[Drone]] minion engaged with you.",
 		"traits": "Android.",
 		"type_code": "villain"
@@ -812,7 +812,7 @@
 		"scheme": 2,
 		"set_code": "ultron",
 		"set_position": 3,
-		"stage": 3,
+		"stage": "III",
 		"text": "Each [[Drone]] minion gets +1 ATK and +1 hit point. Ultron cannot take damage while a [[Drone]] minion is in play.\n<b>When Revealed</b>: Search the encounter deck and discard pile for the Ultron's Imperative side scheme and reveal it. Then shuffle the encounter deck.",
 		"traits": "Android.",
 		"type_code": "villain"
@@ -829,7 +829,7 @@
 		"quantity": 1,
 		"set_code": "ultron",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1A",
 		"text": "<b>Contents</b>: Ultron (I) and Ultron (II). <i>(Ultron (II) and Ultron (III) instead for expert mode.)</i> Ultron and Standard encounter sets. One modular encounter set <i>(recommended: Under Attack).</i>\n<b>Setup</b>: Put the Ultron Drones environment into play. Shuffle the encounter deck. Advanced to stage 1B.",
 		"type_code": "main_scheme"
 	},
@@ -848,7 +848,7 @@
 		"quantity": 1,
 		"set_code": "ultron",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1B",
 		"text": "<b>When Revealed</b>: Each player puts the top card of their deck into play facedown, engaged with them as a [[Drone]] minion.",
 		"threat": 3,
 		"type_code": "main_scheme"
@@ -865,7 +865,7 @@
 		"quantity": 1,
 		"set_code": "ultron",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2A",
 		"text": "<b>When Revealed</b>: Each player puts the top card of their deck into play facedown, engaged with them as a [[Drone]] minion. Advance to stage 2B.",
 		"type_code": "main_scheme"
 	},
@@ -884,7 +884,7 @@
 		"quantity": 1,
 		"set_code": "ultron",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2B",
 		"text": "<b>Forced Response</b>: After placing threat here during step one of the villain phase, each player must choose to either place 2 threat here or put the top card of their deck into play facedown, engaged with them as a [[Drone]] minion.",
 		"threat": 10,
 		"type_code": "main_scheme"
@@ -901,7 +901,7 @@
 		"quantity": 1,
 		"set_code": "ultron",
 		"set_position": 6,
-		"stage": 3,
+		"stage": "3A",
 		"text": "<b>When Revealed</b>: Each player puts the top card of their deck into play facedown, engaged with them as a [[Drone]] minion. Advance to stage 3B.",
 		"type_code": "main_scheme"
 	},
@@ -920,7 +920,7 @@
 		"quantity": 1,
 		"set_code": "ultron",
 		"set_position": 6,
-		"stage": 3,
+		"stage": "3B",
 		"text": "Threat cannot be removed from this scheme.\n<b>If this stage is completed, the players lose the game</b>",
 		"threat": 5,
 		"type_code": "main_scheme"

--- a/pack/gmw_encounter.json
+++ b/pack/gmw_encounter.json
@@ -25,7 +25,7 @@
 		"quantity": 1,
 		"set_code": "groot_nemesis",
 		"set_position": 1,
-		"text": "<b>Forced Response:</b> After the villain phase begins, deal 2 indirect damage to each player.",
+		"text": "<b>Forced Response</b>: After the villain phase begins, deal 2 indirect damage to each player.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -46,7 +46,7 @@
 		"scheme_star": true,
 		"set_code": "groot_nemesis",
 		"set_position": 2,
-		"text": "[star] <b>Forced Response:</b> After Furnax activates, deal 2 indirect damage to each player.\n<i>(Groot's nemesis minion.)</i>",
+		"text": "[star] <b>Forced Response</b>: After Furnax activates, deal 2 indirect damage to each player.\n<i>(Groot's nemesis minion.)</i>",
 		"traits": "Leviatron.",
 		"type_code": "minion"
 	},
@@ -61,7 +61,7 @@
 		"quantity": 3,
 		"set_code": "groot_nemesis",
 		"set_position": 3,
-		"text": "<b>When Revealed:</b> Take 2 indirect damage. If Blazing Inferno is in play, take 1 additional indirect damage. If Furnax is in play, take 1 additional indirect damage.",
+		"text": "<b>When Revealed</b>: Take 2 indirect damage. If Blazing Inferno is in play, take 1 additional indirect damage. If Furnax is in play, take 1 additional indirect damage.",
 		"type_code": "treachery"
 	},
 	{
@@ -125,7 +125,7 @@
 		"quantity": 1,
 		"set_code": "rocket_nemesis",
 		"set_position": 3,
-		"text": "Attach to Blackjack O'Hare, if able. If you cannot, attach to the villain.\n<b>Hero Action:</b> Spend [mental][mental][mental] resources → Discard this card.",
+		"text": "Attach to Blackjack O'Hare, if able. If you cannot, attach to the villain.\n<b>Hero Action</b>: Spend [mental][mental][mental] resources → Discard this card.",
 		"traits": "Tech. Weapon.",
 		"type_code": "attachment"
 	},
@@ -141,7 +141,7 @@
 		"quantity": 2,
 		"set_code": "rocket_nemesis",
 		"set_position": 4,
-		"text": "<b>When Revealed:</b> Discard cards from the top of the encounter deck until you discard a minion. Reveal that minion, then give it a tough status card.",
+		"text": "<b>When Revealed</b>: Discard cards from the top of the encounter deck until you discard a minion. Reveal that minion, then give it a tough status card.",
 		"type_code": "treachery"
 	},
 	{
@@ -161,7 +161,7 @@
 		"scheme_star": true,
 		"set_code": "brotherhood_of_badoon",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "[star] <b>Forced Response</b>: After Drang schemes, resolve the Badoon Ship's <i>\"Charge Up\"</i> ability.",
 		"traits": "Badoon.",
 		"type_code": "villain"
@@ -182,8 +182,8 @@
 		"scheme_star": true,
 		"set_code": "brotherhood_of_badoon",
 		"set_position": 2,
-		"stage": 2,
-		"text": "<b>When Revealed:</b> If Drang's Spear is in play, give Drang 1 facedown boost card; otherwise, search the encounter deck and discard pile for Drang's Spear, reveal it, and shuffle the encounter deck.\n[star] <b>Forced Response</b>: After Drang schemes, resolve the Badoon Ship's <i>\"Charge Up\"</i> ability.",
+		"stage": "II",
+		"text": "<b>When Revealed</b>: If Drang's Spear is in play, give Drang 1 facedown boost card; otherwise, search the encounter deck and discard pile for Drang's Spear, reveal it, and shuffle the encounter deck.\n[star] <b>Forced Response</b>: After Drang schemes, resolve the Badoon Ship's <i>\"Charge Up\"</i> ability.",
 		"traits": "Badoon.",
 		"type_code": "villain"
 	},
@@ -203,8 +203,8 @@
 		"scheme_star": true,
 		"set_code": "brotherhood_of_badoon",
 		"set_position": 3,
-		"stage": 3,
-		"text": "<b>When Revealed:</b> Discard the top 4[per_hero] cards of the encounter deck. Each time a minion is discarded this way, put it into play engaged with the player who is engaged with the fewest minions.\n[star] <b>Forced Response</b>: After Drang activates, resolve the Badoon Ship's <i>\"Charge Up\"</i> ability.",
+		"stage": "III",
+		"text": "<b>When Revealed</b>: Discard the top 4[per_hero] cards of the encounter deck. Each time a minion is discarded this way, put it into play engaged with the player who is engaged with the fewest minions.\n[star] <b>Forced Response</b>: After Drang activates, resolve the Badoon Ship's <i>\"Charge Up\"</i> ability.",
 		"traits": "Badoon.",
 		"type_code": "villain"
 	},
@@ -221,8 +221,8 @@
 		"quantity": 1,
 		"set_code": "brotherhood_of_badoon",
 		"set_position": 4,
-		"stage": 1,
-		"text": "<b>Contents:</b> Drang (I) and Drang (II). (Drang (II) and Drang(III) instead for expert mode.) Brotherhood of Badoon, Ship Command, and Standard encounter sets. One modular encounter set (Band of Badoon).\n<b>Setup:</b> Put the Badoon Ship environment and the Milano support into play.",
+		"stage": "1A",
+		"text": "<b>Contents</b>: Drang (I) and Drang (II). (Drang (II) and Drang(III) instead for expert mode.) Brotherhood of Badoon, Ship Command, and Standard encounter sets. One modular encounter set (Band of Badoon).\n<b>Setup</b>: Put the Badoon Ship environment and the Milano support into play.",
 		"threat": 0,
 		"type_code": "main_scheme"
 	},
@@ -240,8 +240,8 @@
 		"quantity": 1,
 		"set_code": "brotherhood_of_badoon",
 		"set_position": 4,
-		"stage": 1,
-		"text": "[star] <b>Forced Response</b>: After resolving step one of the villain phase, resolve the Badoon Ship's <i>\"Charge Up\"</i> ability.\n<b>First Player Action:</b> Exhaust the Milano → remove 3 threat from this scheme.",
+		"stage": "1B",
+		"text": "[star] <b>Forced Response</b>: After resolving step one of the villain phase, resolve the Badoon Ship's <i>\"Charge Up\"</i> ability.\n<b>First Player Action</b>: Exhaust the Milano → remove 3 threat from this scheme.",
 		"threat": 8,
 		"type_code": "main_scheme"
 	},
@@ -258,8 +258,8 @@
 		"quantity": 1,
 		"set_code": "brotherhood_of_badoon",
 		"set_position": 5,
-		"stage": 2,
-		"text": "<b>When Revealed:</b> Resolve the Badoon Ship's <i>\"Charge Up\"</i> ability.",
+		"stage": "2A",
+		"text": "<b>When Revealed</b>: Resolve the Badoon Ship's <i>\"Charge Up\"</i> ability.",
 		"threat": 0,
 		"type_code": "main_scheme"
 	},
@@ -277,8 +277,8 @@
 		"quantity": 1,
 		"set_code": "brotherhood_of_badoon",
 		"set_position": 5,
-		"stage": 2,
-		"text": "[star] <b>Forced Response</b>: After resolving step one of the villain phase, resolve the Badoon Ship's <i>\"Charge Up\"</i> ability.\n<b>First Player Action:</b> Exhaust the Milano → choose to either remove 3 threat from this scheme or deal 3 damage to a minion.\n<b>If this stage is completed, the players lose the game.</b>",
+		"stage": "2B",
+		"text": "[star] <b>Forced Response</b>: After resolving step one of the villain phase, resolve the Badoon Ship's <i>\"Charge Up\"</i> ability.\n<b>First Player Action</b>: Exhaust the Milano → choose to either remove 3 threat from this scheme or deal 3 damage to a minion.\n<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 8,
 		"type_code": "main_scheme"
 	},
@@ -294,7 +294,7 @@
 		"quantity": 1,
 		"set_code": "brotherhood_of_badoon",
 		"set_position": 6,
-		"text": "<i>Charge Up</i> — <b>Special:</b> Place 1 barrage counter here. Then, if there are 4 or more barrage counters here, deal 2 indirect damage to each player and remove all barrage counters from here.",
+		"text": "<i>Charge Up</i> — <b>Special</b>: Place 1 barrage counter here. Then, if there are 4 or more barrage counters here, deal 2 indirect damage to each player and remove all barrage counters from here.",
 		"traits": "Aerial. Vehicle.",
 		"type_code": "environment"
 	},
@@ -310,7 +310,7 @@
 		"quantity": 1,
 		"set_code": "brotherhood_of_badoon",
 		"set_position": 7,
-		"text": "Attach to Drang.\nDrang gains stalwart. (He cannot be stunned or confused.)\n<b>Hero Action:</b> Spend [mental][physical][physical] resources → discard this card.",
+		"text": "Attach to Drang.\nDrang gains stalwart. (He cannot be stunned or confused.)\n<b>Hero Action</b>: Spend [mental][physical][physical] resources → discard this card.",
 		"traits": "Weapon.",
 		"type_code": "attachment"
 	},
@@ -348,7 +348,7 @@
 		"scheme_crisis": 1,
 		"set_code": "brotherhood_of_badoon",
 		"set_position": 10,
-		"text": "Hinder 2[per_hero]. <i>(When revealed, place 2[per_hero] threat here.)</i>\n<b>First Player Action:</b> Exhaust the Milano → remove 3 threat from this scheme.",
+		"text": "Hinder 2[per_hero]. <i>(When revealed, place 2[per_hero] threat here.)</i>\n<b>First Player Action</b>: Exhaust the Milano → remove 3 threat from this scheme.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -363,7 +363,7 @@
 		"quantity": 1,
 		"set_code": "brotherhood_of_badoon",
 		"set_position": 11,
-		"text": "<b>Forced Response:</b> After resolving step one of the villain phase, resolve the Badoon Ship's <i>\"Charge Up\"</i> ability.\n<b>First Player Action:</b> Exhaust the Milano → remove 3 threat from this scheme.",
+		"text": "<b>Forced Response</b>: After resolving step one of the villain phase, resolve the Badoon Ship's <i>\"Charge Up\"</i> ability.\n<b>First Player Action</b>: Exhaust the Milano → remove 3 threat from this scheme.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -380,7 +380,7 @@
 		"scheme_hazard": 1,
 		"set_code": "brotherhood_of_badoon",
 		"set_position": 12,
-		"text": "Hinder 3[per_hero]. <i>When revealed, place 3[per_hero] threat here.)</i>\n<b>First Player Action:</b> Exhaust the Milano → remove 3 threat from this scheme.",
+		"text": "Hinder 3[per_hero]. <i>When revealed, place 3[per_hero] threat here.)</i>\n<b>First Player Action</b>: Exhaust the Milano → remove 3 threat from this scheme.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -396,7 +396,7 @@
 		"scheme_amplify": 1,
 		"set_code": "brotherhood_of_badoon",
 		"set_position": 13,
-		"text": "<b>First Player Action:</b> Exhaust the Milano → remove 3 threat from this scheme.",
+		"text": "<b>First Player Action</b>: Exhaust the Milano → remove 3 threat from this scheme.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -415,8 +415,8 @@
 		"scheme": 2,
 		"set_code": "infiltrate_the_museum",
 		"set_position": 1,
-		"stage": 1,
-		"text": "<b>Forced Interrupt:</b> When a card <i>(player or encounter)</i> would be placed into a discard pile from play, put it faceup into The Collection instead.",
+		"stage": "I",
+		"text": "<b>Forced Interrupt</b>: When a card <i>(player or encounter)</i> would be placed into a discard pile from play, put it faceup into The Collection instead.",
 		"traits": "Elder.",
 		"type_code": "villain"
 	},
@@ -435,8 +435,8 @@
 		"scheme": 3,
 		"set_code": "infiltrate_the_museum",
 		"set_position": 2,
-		"stage": 2,
-		"text": "<b>When Revealed:</b> In player order, each player must choose to either put the top card of their deck faceup into The Collection or take 3 damage.\n<b>Forced Interrupt:</b> When a card <i>(player or encounter)</i> would be placed into a discard pile from play, put it faceup into The Collection instead.",
+		"stage": "II",
+		"text": "<b>When Revealed</b>: In player order, each player must choose to either put the top card of their deck faceup into The Collection or take 3 damage.\n<b>Forced Interrupt</b>: When a card <i>(player or encounter)</i> would be placed into a discard pile from play, put it faceup into The Collection instead.",
 		"traits": "Elder.",
 		"type_code": "villain"
 	},
@@ -455,8 +455,8 @@
 		"scheme": 4,
 		"set_code": "infiltrate_the_museum",
 		"set_position": 3,
-		"stage": 3,
-		"text": "<b>When Revealed:</b> Put the top card of each player's deck faceup into The Collection. Place 1 threat on the main scheme for each card in The Collection.\n<b>Forced Interrupt:</b> When a card would be placed into a discard pile from play, put it faceup into The Collection instead, then place 1 threat on the main scheme.",
+		"stage": "III",
+		"text": "<b>When Revealed</b>: Put the top card of each player's deck faceup into The Collection. Place 1 threat on the main scheme for each card in The Collection.\n<b>Forced Interrupt</b>: When a card would be placed into a discard pile from play, put it faceup into The Collection instead, then place 1 threat on the main scheme.",
 		"traits": "Elder.",
 		"type_code": "villain"
 	},
@@ -472,8 +472,8 @@
 		"quantity": 1,
 		"set_code": "infiltrate_the_museum",
 		"set_position": 4,
-		"stage": 1,
-		"text": "<b>Contents:</b> Collector (I) and Collector (II). <i>(Collector (II) and Collector (III) instead for expert mode.)</i> Infiltrate the Museum, Galactic Artifacts, and Standard encounter sets. One modular encounter set <i>(Menagerie Medley).</i>\n<b>Setup:</b> Create \"The Collection\" game area <i>(see insert for details).</i> Put the top card of each player's deck faceup into The Collection.",
+		"stage": "1A",
+		"text": "<b>Contents</b>: Collector (I) and Collector (II). <i>(Collector (II) and Collector (III) instead for expert mode.)</i> Infiltrate the Museum, Galactic Artifacts, and Standard encounter sets. One modular encounter set <i>(Menagerie Medley).</i>\n<b>Setup</b>: Create \"The Collection\" game area <i>(see insert for details).</i> Put the top card of each player's deck faceup into The Collection.",
 		"threat": 0,
 		"type_code": "main_scheme"
 	},
@@ -490,8 +490,8 @@
 		"quantity": 1,
 		"set_code": "infiltrate_the_museum",
 		"set_position": 4,
-		"stage": 1,
-		"text": "<b>Hero Action:</b> Choose to either exhaust your hero or spend 2 resources of any type → discard 1 card from The Collection <i>(to its owner's discard pile).</i> (Limit once per round per player.)\n<b>If there are at least 5[per_hero] cards in The Collection or if this stage is completed, the players lose the game.</b>",
+		"stage": "1B",
+		"text": "<b>Hero Action</b>: Choose to either exhaust your hero or spend 2 resources of any type → discard 1 card from The Collection <i>(to its owner's discard pile).</i> (Limit once per round per player.)\n<b>If there are at least 5[per_hero] cards in The Collection or if this stage is completed, the players lose the game.</b>",
 		"threat": 10,
 		"type_code": "main_scheme"
 	},
@@ -507,7 +507,7 @@
 		"quantity": 1,
 		"set_code": "infiltrate_the_museum",
 		"set_position": 5,
-		"text": "Attach to Collector.\n<b>Forced Interrupt:</b> When Collector would take any amount of damage, put this card faceup into The Collection → prevent all of that damage, then place threat on the main scheme equal to the amount prevented this way.\n<hr />\n[star] <b>Boost</b>: After this activation ends, reveal this card.",
+		"text": "Attach to Collector.\n<b>Forced Interrupt</b>: When Collector would take any amount of damage, put this card faceup into The Collection → prevent all of that damage, then place threat on the main scheme equal to the amount prevented this way.\n<hr />\n[star] <b>Boost</b>: After this activation ends, reveal this card.",
 		"traits": "Illusion.",
 		"type_code": "attachment"
 	},
@@ -542,7 +542,7 @@
 		"quantity": 2,
 		"set_code": "infiltrate_the_museum",
 		"set_position": 7,
-		"text": "<b>When Revealed:</b> Put the lowest cost card you control faceup into The Collection. If you cannot, this card gains surge.\n<hr />\n[star] <b>Boost</b>: If there are 3[per_hero] or fewer cards in The Collection, put the top card of your deck faceup into The Collection.",
+		"text": "<b>When Revealed</b>: Put the lowest cost card you control faceup into The Collection. If you cannot, this card gains surge.\n<hr />\n[star] <b>Boost</b>: If there are 3[per_hero] or fewer cards in The Collection, put the top card of your deck faceup into The Collection.",
 		"type_code": "treachery"
 	},
 	{
@@ -556,7 +556,7 @@
 		"quantity": 2,
 		"set_code": "infiltrate_the_museum",
 		"set_position": 9,
-		"text": "<b>When Revealed:</b> Choose one:\n- Put the highest cost card from your hand faceup into The Collection.\n- Discard the highest cost card from your hand, then place threat on the main scheme equal to its printed cost.",
+		"text": "<b>When Revealed</b>: Choose one:\n- Put the highest cost card from your hand faceup into The Collection.\n- Discard the highest cost card from your hand, then place threat on the main scheme equal to its printed cost.",
 		"type_code": "treachery"
 	},
 	{
@@ -570,7 +570,7 @@
 		"quantity": 2,
 		"set_code": "infiltrate_the_museum",
 		"set_position": 11,
-		"text": "<b>When Revealed (Alter-Ego):</b> Choose to either spend [physical][physical] resources or put the top card of your deck faceup into The Collection.\n<b>When Revealed (Hero):</b> Collector attacks you with +1 ATK. If you take any amount of damage from that attack, put the top card of your deck faceup into The Collection.",
+		"text": "<b>When Revealed (Alter-Ego)</b>: Choose to either spend [physical][physical] resources or put the top card of your deck faceup into The Collection.\n<b>When Revealed (Hero)</b>: Collector attacks you with +1 ATK. If you take any amount of damage from that attack, put the top card of your deck faceup into The Collection.",
 		"type_code": "treachery"
 	},
 	{
@@ -584,7 +584,7 @@
 		"quantity": 1,
 		"set_code": "infiltrate_the_museum",
 		"set_position": 13,
-		"text": "<b>When Revealed:</b> Discard an upgrade or support you control. If no cards were discarded this way, this card gains surge.",
+		"text": "<b>When Revealed</b>: Discard an upgrade or support you control. If no cards were discarded this way, this card gains surge.",
 		"type_code": "treachery"
 	},
 	{
@@ -605,8 +605,8 @@
 		"scheme_star": true,
 		"set_code": "escape_the_museum",
 		"set_position": 1,
-		"stage": 0,
-		"text": "[star] Collector gets +X SCH and +X ATK, where X is equal to the main scheme's current stage number.\n<b>Forced Interrupt:</b> When Collector would be defeated, remove 3[per_hero] threat from the main scheme and flip this card instead.",
+		"stage": "A1",
+		"text": "[star] Collector gets +X SCH and +X ATK, where X is equal to the main scheme's current stage number.\n<b>Forced Interrupt</b>: When Collector would be defeated, remove 3[per_hero] threat from the main scheme and flip this card instead.",
 		"traits": "Elder.",
 		"type_code": "villain"
 	},
@@ -627,8 +627,8 @@
 		"scheme": 0,
 		"set_code": "escape_the_museum",
 		"set_position": 1,
-		"stage": 0,
-		"text": "Collector cannot be defeated.\n<b>Forced Interrupt:</b> When the round ends, flip this card, then set Collector's hit point dial to his printed hit points.",
+		"stage": "A2",
+		"text": "Collector cannot be defeated.\n<b>Forced Interrupt</b>: When the round ends, flip this card, then set Collector's hit point dial to his printed hit points.",
 		"traits": "Elder. Wounded.",
 		"type_code": "villain"
 	},
@@ -650,8 +650,8 @@
 		"scheme_star": true,
 		"set_code": "escape_the_museum",
 		"set_position": 2,
-		"stage": 0,
-		"text": "[star] Collector gets +X SCH and +X ATK, where X is equal to the main scheme's current stage number.\n<b>Forced Interrupt:</b> When Collector would be defeated, remove 3[per_hero] threat from the main scheme and flip this card instead.",
+		"stage": "B1",
+		"text": "[star] Collector gets +X SCH and +X ATK, where X is equal to the main scheme's current stage number.\n<b>Forced Interrupt</b>: When Collector would be defeated, remove 3[per_hero] threat from the main scheme and flip this card instead.",
 		"traits": "Elder.",
 		"type_code": "villain"
 	},
@@ -672,8 +672,8 @@
 		"scheme": 2,
 		"set_code": "escape_the_museum",
 		"set_position": 2,
-		"stage": 0,
-		"text": "Collector cannot be defeated.\n<b>Forced Interrupt:</b> When the round ends, flip this card, then set Collector's hit point dial to his printed hit points.",
+		"stage": "B2",
+		"text": "Collector cannot be defeated.\n<b>Forced Interrupt</b>: When the round ends, flip this card, then set Collector's hit point dial to his printed hit points.",
 		"traits": "Elder. Wounded.",
 		"type_code": "villain"
 	},
@@ -689,8 +689,8 @@
 		"quantity": 1,
 		"set_code": "escape_the_museum",
 		"set_position": 3,
-		"stage": 1,
-		"text": "<b>Contents:</b> Collector (A1) <i>(Collector (B1) instead for expert mode.)</i> Escape the Museum, Galactic Artifacts, Ship Command, and Standard encounter sets. One modular encounter set <i>(Menagerie Medley).</i>\n<b>Setup:</b> Put the Library Labyrinth environment into play. Set aside the Ship Command modular encounter set.",
+		"stage": "1A",
+		"text": "<b>Contents</b>: Collector (A1) <i>(Collector (B1) instead for expert mode.)</i> Escape the Museum, Galactic Artifacts, Ship Command, and Standard encounter sets. One modular encounter set <i>(Menagerie Medley).</i>\n<b>Setup</b>: Put the Library Labyrinth environment into play. Set aside the Ship Command modular encounter set.",
 		"threat": 0,
 		"type_code": "main_scheme"
 	},
@@ -708,8 +708,8 @@
 		"quantity": 1,
 		"set_code": "escape_the_museum",
 		"set_position": 3,
-		"stage": 1,
-		"text": "<b>Forced Interrupt:</b> When the last threat is removed from this scheme, advance to stage 2A <i>(the players win by advancing).</i>\n<b>If this stage is completed, the players lose the game.</b>",
+		"stage": "1B",
+		"text": "<b>Forced Interrupt</b>: When the last threat is removed from this scheme, advance to stage 2A <i>(the players win by advancing).</i>\n<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 11,
 		"type_code": "main_scheme"
 	},
@@ -726,8 +726,8 @@
 		"quantity": 1,
 		"set_code": "escape_the_museum",
 		"set_position": 4,
-		"stage": 2,
-		"text": "<b>When Revealed:</b> Put the set-aside Milano support from the Ship Command encounter set into play under the first player's control.",
+		"stage": "2A",
+		"text": "<b>When Revealed</b>: Put the set-aside Milano support from the Ship Command encounter set into play under the first player's control.",
 		"threat": 0,
 		"type_code": "main_scheme"
 	},
@@ -745,8 +745,8 @@
 		"quantity": 1,
 		"set_code": "escape_the_museum",
 		"set_position": 4,
-		"stage": 2,
-		"text": "<b>Forced Interrupt:</b> When the last threat is removed from this scheme, advance to stage 3A <i>(the players win by advancing).</i>\n<b>If this stage is completed, the players lose the game.</b>",
+		"stage": "2B",
+		"text": "<b>Forced Interrupt</b>: When the last threat is removed from this scheme, advance to stage 3A <i>(the players win by advancing).</i>\n<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 15,
 		"type_code": "main_scheme"
 	},
@@ -763,8 +763,8 @@
 		"quantity": 1,
 		"set_code": "escape_the_museum",
 		"set_position": 5,
-		"stage": 3,
-		"text": "<b>When Revealed:</b> Flip Library Labyrinth. Place 1 acceleration token on the main scheme. Shuffle the remaining cards from the set-aside Ship Command encounter set into the encounter deck.",
+		"stage": "3A",
+		"text": "<b>When Revealed</b>: Flip Library Labyrinth. Place 1 acceleration token on the main scheme. Shuffle the remaining cards from the set-aside Ship Command encounter set into the encounter deck.",
 		"threat": 0,
 		"type_code": "main_scheme"
 	},
@@ -782,8 +782,8 @@
 		"quantity": 1,
 		"set_code": "escape_the_museum",
 		"set_position": 5,
-		"stage": 3,
-		"text": "<b>First Player Action:</b> Exhaust the Milano → remove 3 threat from here.\n<b>If there is no threat here, the players win the game.</b>\n<b>If this stage is completed, the players lose the game.</b>",
+		"stage": "3B",
+		"text": "<b>First Player Action</b>: Exhaust the Milano → remove 3 threat from here.\n<b>If there is no threat here, the players win the game.</b>\n<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 12,
 		"type_code": "main_scheme"
 	},
@@ -800,7 +800,7 @@
 		"quantity": 1,
 		"set_code": "escape_the_museum",
 		"set_position": 6,
-		"text": "\"<i>This way?</i>\" — <b>Hero Action:</b> Deal yourself 1 facedown encounter card → remove 5 threat from the main scheme. (Limit once per round per player.)",
+		"text": "\"<i>This way?</i>\" — <b>Hero Action</b>: Deal yourself 1 facedown encounter card → remove 5 threat from the main scheme. (Limit once per round per player.)",
 		"traits": "Location.",
 		"type_code": "environment"
 	},
@@ -816,7 +816,7 @@
 		"quantity": 1,
 		"set_code": "escape_the_museum",
 		"set_position": 6,
-		"text": "\"<i>Hold on to your butts!</i>\" — <b>Forced Interrupt:</b> When the villain phase begins, choose one:\n\u2022 Exhaust the Milano → assign 2[per_hero] indirect damage among players.\n\u2022 Assign 3[per_hero] indirect damage among players.",
+		"text": "\"<i>Hold on to your butts!</i>\" — <b>Forced Interrupt</b>: When the villain phase begins, choose one:\n\u2022 Exhaust the Milano → assign 2[per_hero] indirect damage among players.\n\u2022 Assign 3[per_hero] indirect damage among players.",
 		"traits": "Aerial. Vehicle.",
 		"type_code": "environment"
 	},
@@ -832,7 +832,7 @@
 		"quantity": 3,
 		"set_code": "escape_the_museum",
 		"set_position": 7,
-		"text": "<b>When Revealed (Alter-Ego):</b> Exhaust your identity. Collector schemes.\n<b>When Revealed (Hero):</b> You are stunned. Collector attacks you.\n<hr />\n[star] <b>Boost</b>: Give Collector a tough status card.",
+		"text": "<b>When Revealed (Alter-Ego)</b>: Exhaust your identity. Collector schemes.\n<b>When Revealed (Hero)</b>: You are stunned. Collector attacks you.\n<hr />\n[star] <b>Boost</b>: Give Collector a tough status card.",
 		"type_code": "treachery"
 	},
 	{
@@ -847,7 +847,7 @@
 		"quantity": 3,
 		"set_code": "escape_the_museum",
 		"set_position": 10,
-		"text": "Incite 1. <i>(When revealed, place 1 threat on the main scheme.)</i>\n<b>When Revealed:</b> You are confused. If you are already confused, choose and discard 1 card you control.",
+		"text": "Incite 1. <i>(When revealed, place 1 threat on the main scheme.)</i>\n<b>When Revealed</b>: You are confused. If you are already confused, choose and discard 1 card you control.",
 		"type_code": "treachery"
 	},
 	{
@@ -867,7 +867,7 @@
 		"scheme_star": true,
 		"set_code": "nebula",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "The first [[Technique]] attachment revealed each round gains surge.\n[star] <b>Forced Interrupt</b>: When Nebula initiates an activation against you, resolve the \"<b>Special</b>\" ability on each [[Technique]] attachment in play, then discard each of those attachments.",
 		"traits": "Criminal.",
 		"type_code": "villain"
@@ -889,7 +889,7 @@
 		"scheme_star": true,
 		"set_code": "nebula",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "II",
 		"text": "The first [[Technique]] attachment revealed each round gains surge.\n[star] <b>Forced Interrupt</b>: When Nebula initiates an activation against you, resolve the \"<b>Special</b>\" ability on each [[Technique]] attachment in play, then choose and discard 1 of those attachments.",
 		"traits": "Criminal.",
 		"type_code": "villain"
@@ -911,7 +911,7 @@
 		"scheme_star": true,
 		"set_code": "nebula",
 		"set_position": 3,
-		"stage": 3,
+		"stage": "III",
 		"text": "The first [[Technique]] attachment revealed each round gains surge.\n[star] <b>Forced Interrupt</b>: When Nebula initiates an activation against you, resolve the \"<b>Special</b>\" ability on each [[Technique]] attachment in play. You may then remove the top card of your deck from the game to choose and discard 1 of those attachments.",
 		"traits": "Criminal.",
 		"type_code": "villain"
@@ -928,8 +928,8 @@
 		"quantity": 1,
 		"set_code": "nebula",
 		"set_position": 4,
-		"stage": 1,
-		"text": "<b>Contents:</b> Nebula (I) and Nebula (II). <i>(Nebula (II) and Nebula (III) instead for expert mode.)</i> Nebula, Power Stone, Ship Command, and Standard encounter sets. One modular encounter set <i>(Space Pirates).</i>\n<b>Setup:</b> Put the Nebula's Ship environment and the Milano support into play. Attach the Power Stone to Nebula. Discard the top 2[per_hero] cards of the encounter deck, then attach each [[Technique]] attachment discarded this way to Nebula.",
+		"stage": "1A",
+		"text": "<b>Contents</b>: Nebula (I) and Nebula (II). <i>(Nebula (II) and Nebula (III) instead for expert mode.)</i> Nebula, Power Stone, Ship Command, and Standard encounter sets. One modular encounter set <i>(Space Pirates).</i>\n<b>Setup</b>: Put the Nebula's Ship environment and the Milano support into play. Attach the Power Stone to Nebula. Discard the top 2[per_hero] cards of the encounter deck, then attach each [[Technique]] attachment discarded this way to Nebula.",
 		"threat": 0,
 		"type_code": "main_scheme"
 	},
@@ -947,7 +947,7 @@
 		"quantity": 1,
 		"set_code": "nebula",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1B",
 		"text": "X is equal to the number of evasion counters on Nebula's Ship.",
 		"threat": 6,
 		"type_code": "main_scheme"
@@ -965,8 +965,8 @@
 		"quantity": 1,
 		"set_code": "nebula",
 		"set_position": 5,
-		"stage": 2,
-		"text": "<b>When Revealed:</b> Place 2 evasion counters on Nebula's Ship. For each evasion counter on Nebula's Ship, discard the top 2 cards of each player deck and the encounter deck.",
+		"stage": "2A",
+		"text": "<b>When Revealed</b>: Place 2 evasion counters on Nebula's Ship. For each evasion counter on Nebula's Ship, discard the top 2 cards of each player deck and the encounter deck.",
 		"threat": 0,
 		"type_code": "main_scheme"
 	},
@@ -984,7 +984,7 @@
 		"quantity": 1,
 		"set_code": "nebula",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2B",
 		"text": "X is equal to the number of evasion counters on Nebula's Ship.\n<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 9,
 		"type_code": "main_scheme"
@@ -1000,7 +1000,7 @@
 		"quantity": 1,
 		"set_code": "nebula",
 		"set_position": 6,
-		"text": "<b>Forced Interrupt:</b> When the villain phase begins, place 1 evasion counter here.\n<i>Shoot the Thrusters!</i> - <b>First Player Action:</b> Exhaust the Milano and spend up to 2 resources of any type → remove 1 evasion counter from here for each resource spent this way.",
+		"text": "<b>Forced Interrupt</b>: When the villain phase begins, place 1 evasion counter here.\n<i>Shoot the Thrusters!</i> - <b>First Player Action</b>: Exhaust the Milano and spend up to 2 resources of any type → remove 1 evasion counter from here for each resource spent this way.",
 		"traits": "Aerial. Vehicle.",
 		"type_code": "environment"
 	},
@@ -1015,7 +1015,7 @@
 		"quantity": 2,
 		"set_code": "nebula",
 		"set_position": 7,
-		"text": "Attach to Nebula.\nNebula cannot take more than 5 damage from a single attack.\n<b>Special:</b> Place 1 threat on the main scheme.\n<hr />\n[star] <b>Boost</b>: After this activation ends, attach this card to Nebula and resolve its <b>\"Special\"</b> ability.",
+		"text": "Attach to Nebula.\nNebula cannot take more than 5 damage from a single attack.\n<b>Special</b>: Place 1 threat on the main scheme.\n<hr />\n[star] <b>Boost</b>: After this activation ends, attach this card to Nebula and resolve its <b>\"Special\"</b> ability.",
 		"traits": "Technique.",
 		"type_code": "attachment"
 	},
@@ -1030,7 +1030,7 @@
 		"quantity": 1,
 		"set_code": "nebula",
 		"set_position": 9,
-		"text": "Attach to Nebula.\nNebula gains stalwart.\n<b>Special:</b> You are stunned. If you are already stunned, give Nebula 1 facedown boost card.\n<hr />\n[star] <b>Boost</b>: After this activation ends, attach this card to Nebula and resolve its <b>\"Special\"</b> ability.",
+		"text": "Attach to Nebula.\nNebula gains stalwart.\n<b>Special</b>: You are stunned. If you are already stunned, give Nebula 1 facedown boost card.\n<hr />\n[star] <b>Boost</b>: After this activation ends, attach this card to Nebula and resolve its <b>\"Special\"</b> ability.",
 		"traits": "Technique.",
 		"type_code": "attachment"
 	},
@@ -1045,7 +1045,7 @@
 		"quantity": 1,
 		"set_code": "nebula",
 		"set_position": 10,
-		"text": "Attach to Nebula.\nNebula gains stalwart.\n<b>Special:</b> Give Nebula a tough status card. If Nebula already has a tough status card, give Nebula 1 facedown boost card.\n<hr />\n[star] <b>Boost</b>: After this activation ends, attach this card to Nebula and resolve its <b>\"Special\"</b> ability.",
+		"text": "Attach to Nebula.\nNebula gains stalwart.\n<b>Special</b>: Give Nebula a tough status card. If Nebula already has a tough status card, give Nebula 1 facedown boost card.\n<hr />\n[star] <b>Boost</b>: After this activation ends, attach this card to Nebula and resolve its <b>\"Special\"</b> ability.",
 		"traits": "Technique.",
 		"type_code": "attachment"
 	},
@@ -1060,7 +1060,7 @@
 		"quantity": 2,
 		"set_code": "nebula",
 		"set_position": 11,
-		"text": "Attach to Nebula.\nNebula gains retaliate 1.\n<b>Special:</b> Take 1 damage.\n<hr />\n[star] <b>Boost</b>: After this activation ends, attach this card to Nebula and resolve its <b>\"Special\"</b> ability.",
+		"text": "Attach to Nebula.\nNebula gains retaliate 1.\n<b>Special</b>: Take 1 damage.\n<hr />\n[star] <b>Boost</b>: After this activation ends, attach this card to Nebula and resolve its <b>\"Special\"</b> ability.",
 		"traits": "Technique.",
 		"type_code": "attachment"
 	},
@@ -1075,7 +1075,7 @@
 		"quantity": 2,
 		"set_code": "nebula",
 		"set_position": 13,
-		"text": "Attach to Nebula.\nReduce the amount of damage Nebula takes from each attack by 1.\n<b>Special:</b> Discard 1 card at random from your hand.\n<hr />\n[star] <b>Boost</b>: After this activation ends, attach this card to Nebula and resolve its <b>\"Special\"</b> ability.",
+		"text": "Attach to Nebula.\nReduce the amount of damage Nebula takes from each attack by 1.\n<b>Special</b>: Discard 1 card at random from your hand.\n<hr />\n[star] <b>Boost</b>: After this activation ends, attach this card to Nebula and resolve its <b>\"Special\"</b> ability.",
 		"traits": "Technique.",
 		"type_code": "attachment"
 	},
@@ -1091,7 +1091,7 @@
 		"scheme_hazard": 1,
 		"set_code": "nebula",
 		"set_position": 15,
-		"text": "<b>When Revealed:</b> Discard cards from the top of the encounter deck until a [[Technique]] attachment is discarded. Reveal that card.",
+		"text": "<b>When Revealed</b>: Discard cards from the top of the encounter deck until a [[Technique]] attachment is discarded. Reveal that card.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1106,7 +1106,7 @@
 		"quantity": 2,
 		"set_code": "nebula",
 		"set_position": 17,
-		"text": "Incite 1. Surge.\n<b>When Revealed:</b> Place 1 evasion counter on Nebula's Ship.\n<hr />\n[star] <b>Boost</b>: Place 1 evasion counter on Nebula's Ship.",
+		"text": "Incite 1. Surge.\n<b>When Revealed</b>: Place 1 evasion counter on Nebula's Ship.\n<hr />\n[star] <b>Boost</b>: Place 1 evasion counter on Nebula's Ship.",
 		"type_code": "treachery"
 	},
 	{
@@ -1121,7 +1121,7 @@
 		"quantity": 2,
 		"set_code": "nebula",
 		"set_position": 19,
-		"text": "<b>When Revealed:</b> Discard cards from the top of the encounter deck until a [[Technique]] attachment is discarded. Reveal that card, then resolve its <b>\"Special\"</b> ability.",
+		"text": "<b>When Revealed</b>: Discard cards from the top of the encounter deck until a [[Technique]] attachment is discarded. Reveal that card, then resolve its <b>\"Special\"</b> ability.",
 		"type_code": "treachery"
 	},
 	{
@@ -1135,7 +1135,7 @@
 		"quantity": 2,
 		"set_code": "nebula",
 		"set_position": 21,
-		"text": "<b>When Revealed (Alter-Ego):</b> Nebula schemes. If threat is placed by this activation, place 1 evasion counter on Nebula's Ship.\n<b>When Revealed (Hero):</b> Nebula attacks you. If damage is dealt by this activation, place 1 evasion counter on Nebula's Ship.",
+		"text": "<b>When Revealed (Alter-Ego)</b>: Nebula schemes. If threat is placed by this activation, place 1 evasion counter on Nebula's Ship.\n<b>When Revealed (Hero)</b>: Nebula attacks you. If damage is dealt by this activation, place 1 evasion counter on Nebula's Ship.",
 		"type_code": "treachery"
 	},
 	{
@@ -1156,7 +1156,7 @@
 		"scheme_star": true,
 		"set_code": "ronan",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "Toughness.\n[star] <b>Forced Interrupt</b>: When Ronan the Accuser activates against you, give him 1 additional boost card if you control the Power Stone.",
 		"traits": "Accuser Corps. Kree.",
 		"type_code": "villain"
@@ -1178,8 +1178,8 @@
 		"scheme_star": true,
 		"set_code": "ronan",
 		"set_position": 2,
-		"stage": 2,
-		"text": "Toughness.\n<b>When Revealed:</b> Search the encounter deck and discard pile for the Cut the Power side scheme and reveal it. <i>(Shuffle.)</i>\n[star] <b>Forced Interrupt</b>: When Ronan the Accuser activates against you, give him 1 additional boost card if you control the Power Stone.",
+		"stage": "II",
+		"text": "Toughness.\n<b>When Revealed</b>: Search the encounter deck and discard pile for the Cut the Power side scheme and reveal it. <i>(Shuffle.)</i>\n[star] <b>Forced Interrupt</b>: When Ronan the Accuser activates against you, give him 1 additional boost card if you control the Power Stone.",
 		"traits": "Accuser Corps. Kree.",
 		"type_code": "villain"
 	},
@@ -1200,8 +1200,8 @@
 		"scheme_star": true,
 		"set_code": "ronan",
 		"set_position": 3,
-		"stage": 3,
-		"text": "Retaliate 1. Toughness.\n<b>When Revealed:</b> Search the encounter deck and discard pile for the Superior Tactics side scheme and reveal it. <i>(Shuffle.)</i>\n[star] <b>Forced Interrupt</b>: When Ronan the Accuser activates against you, give him 1 additional boost card if you control the Power Stone.",
+		"stage": "III",
+		"text": "Retaliate 1. Toughness.\n<b>When Revealed</b>: Search the encounter deck and discard pile for the Superior Tactics side scheme and reveal it. <i>(Shuffle.)</i>\n[star] <b>Forced Interrupt</b>: When Ronan the Accuser activates against you, give him 1 additional boost card if you control the Power Stone.",
 		"traits": "Accuser Corps. Kree.",
 		"type_code": "villain"
 	},
@@ -1217,8 +1217,8 @@
 		"quantity": 1,
 		"set_code": "ronan",
 		"set_position": 4,
-		"stage": 1,
-		"text": "<b>Contents:</b> Ronan the Accuser (I) and Ronan the Accuser (II). <i>(Ronan the Accuser (II) and Ronan the Accuser (III) instead for expert mode.)</i> Ronan the Accuser, Power Stone, Ship Command, and Standard encounter sets. One modular encounter set <i>(Kree Militants).</i>\n<b>Setup:</b> Put the Kree Command Ship environment and the Milano support into play. Attach the Universal Weapon to Ronan the Accuser. Attach the Power Stone to the first player.",
+		"stage": "1A",
+		"text": "<b>Contents</b>: Ronan the Accuser (I) and Ronan the Accuser (II). <i>(Ronan the Accuser (II) and Ronan the Accuser (III) instead for expert mode.)</i> Ronan the Accuser, Power Stone, Ship Command, and Standard encounter sets. One modular encounter set <i>(Kree Militants).</i>\n<b>Setup</b>: Put the Kree Command Ship environment and the Milano support into play. Attach the Universal Weapon to Ronan the Accuser. Attach the Power Stone to the first player.",
 		"threat": 0,
 		"type_code": "main_scheme"
 	},
@@ -1236,8 +1236,8 @@
 		"quantity": 1,
 		"set_code": "ronan",
 		"set_position": 4,
-		"stage": 1,
-		"text": "<b>First Player Action:</b> Exhaust the Milano → remove 3 threat from this scheme.",
+		"stage": "1B",
+		"text": "<b>First Player Action</b>: Exhaust the Milano → remove 3 threat from this scheme.",
 		"threat": 7,
 		"type_code": "main_scheme"
 	},
@@ -1254,8 +1254,8 @@
 		"quantity": 1,
 		"set_code": "ronan",
 		"set_position": 5,
-		"stage": 2,
-		"text": "<b>When Revealed:</b> Attach the Power Stone to Ronan the Accuser. If it is already attached to him, give him 1 facedown boost card.",
+		"stage": "2A",
+		"text": "<b>When Revealed</b>: Attach the Power Stone to Ronan the Accuser. If it is already attached to him, give him 1 facedown boost card.",
 		"threat": 0,
 		"type_code": "main_scheme"
 	},
@@ -1273,7 +1273,7 @@
 		"quantity": 1,
 		"set_code": "ronan",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2B",
 		"text": "While the Power Stone is attached to Ronan the Accuser, threat cannot be removed from this scheme.\n<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 10,
 		"type_code": "main_scheme"
@@ -1290,7 +1290,7 @@
 		"scheme_hazard": 1,
 		"set_code": "ronan",
 		"set_position": 6,
-		"text": "<b>First Player Interrupt:</b> When a treachery card is revealed from the encounter deck, exhaust the Milano and spend 1 resource of any type → cancel that card's <b>\"When Revealed\" effects.",
+		"text": "<b>First Player Interrupt</b>: When a treachery card is revealed from the encounter deck, exhaust the Milano and spend 1 resource of any type → cancel that card's <b>\"When Revealed\" effects.",
 		"traits": "Aerial. Vehicle.",
 		"type_code": "environment"
 	},
@@ -1306,7 +1306,7 @@
 		"quantity": 1,
 		"set_code": "ronan",
 		"set_position": 7,
-		"text": "Attach to Ronan the Accuser.\nRonan the Accuser gains stalwart.\n<b>Hero Action:</b> Take 2 damage and deal yourself 1 facedown encounter card → shuffle Universal Weapon into the encounter deck.\n<hr />\n[star] <b>Boost</b>: Attach Universal Weapon to Ronan the Accuser.",
+		"text": "Attach to Ronan the Accuser.\nRonan the Accuser gains stalwart.\n<b>Hero Action</b>: Take 2 damage and deal yourself 1 facedown encounter card → shuffle Universal Weapon into the encounter deck.\n<hr />\n[star] <b>Boost</b>: Attach Universal Weapon to Ronan the Accuser.",
 		"traits": "Weapon.",
 		"type_code": "attachment"
 	},
@@ -1357,7 +1357,7 @@
 		"scheme_acceleration": 2,
 		"set_code": "ronan",
 		"set_position": 11,
-		"text": "Hinder 2[per_hero] <i>(When revealed, place 2[per_hero] threat here.)</i>.\n<b>First Player Action:</b> Exhaust the Milano → remove 3 threat from this scheme.",
+		"text": "Hinder 2[per_hero] <i>(When revealed, place 2[per_hero] threat here.)</i>.\n<b>First Player Action</b>: Exhaust the Milano → remove 3 threat from this scheme.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1373,7 +1373,7 @@
 		"quantity": 1,
 		"set_code": "ronan",
 		"set_position": 13,
-		"text": "The Power Stone cannot be unattached from Ronan the Accuser.\n<b>When Revealed:</b> Attach the Power Stone to Ronan the Accuser. If it is already attached to him, place 1[per_hero] threat here.",
+		"text": "The Power Stone cannot be unattached from Ronan the Accuser.\n<b>When Revealed</b>: Attach the Power Stone to Ronan the Accuser. If it is already attached to him, place 1[per_hero] threat here.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1387,7 +1387,7 @@
 		"quantity": 2,
 		"set_code": "ronan",
 		"set_position": 14,
-		"text": "<b>When Revealed:</b> Ronan the Accuser attacks the player who controls the Power Stone <i>(even if that player is in alter-ego form).</i> If no attack was made this way, this card gains surge.\n<hr />\n[star] <b>Boost</b>: Attach the Power Stone to Ronan the Accuser.",
+		"text": "<b>When Revealed</b>: Ronan the Accuser attacks the player who controls the Power Stone <i>(even if that player is in alter-ego form).</i> If no attack was made this way, this card gains surge.\n<hr />\n[star] <b>Boost</b>: Attach the Power Stone to Ronan the Accuser.",
 		"type_code": "treachery"
 	},
 	{
@@ -1402,7 +1402,7 @@
 		"quantity": 2,
 		"set_code": "ronan",
 		"set_position": 16,
-		"text": "Surge.\n<b>When Revealed:</b> Give Ronan the Accuser a tough status card. If he already has a tough status card, take 1 damage.",
+		"text": "Surge.\n<b>When Revealed</b>: Give Ronan the Accuser a tough status card. If he already has a tough status card, take 1 damage.",
 		"type_code": "treachery"
 	},
 	{
@@ -1417,7 +1417,7 @@
 		"quantity": 3,
 		"set_code": "ronan",
 		"set_position": 18,
-		"text": "<b>When Revealed (Alter-Ego):</b> Ronan the Accuser schemes with +1 SCH.\n<b>When Revealed (Hero):</b> Ronan the Accuser attacks you with +1 ATK.\n<hr />\n[star] <b>Boost</b>: Give the villain 1 additional boost card for this activation.",
+		"text": "<b>When Revealed (Alter-Ego)</b>: Ronan the Accuser schemes with +1 SCH.\n<b>When Revealed (Hero)</b>: Ronan the Accuser attacks you with +1 ATK.\n<hr />\n[star] <b>Boost</b>: Give the villain 1 additional boost card for this activation.",
 		"type_code": "treachery"
 	},
 	{
@@ -1434,7 +1434,7 @@
 		"scheme": 1,
 		"set_code": "band_of_badoon",
 		"set_position": 1,
-		"text": "<b>Forced Response:</b> After Badoon Assassin engages your hero, it attacks you with +2 ATK.\n<hr />\n[star] <b>Boost</b>: If this activation is an attack, this attack gains overkill, piercing, and ranged.",
+		"text": "<b>Forced Response</b>: After Badoon Assassin engages your hero, it attacks you with +2 ATK.\n<hr />\n[star] <b>Boost</b>: If this activation is an attack, this attack gains overkill, piercing, and ranged.",
 		"traits": "Badoon.",
 		"type_code": "minion"
 	},
@@ -1452,7 +1452,7 @@
 		"scheme": 2,
 		"set_code": "band_of_badoon",
 		"set_position": 3,
-		"text": "<b>Forced Response:</b> After Badoon Grunt engages you, if there are no other minions engaged with you, deal yourself 1 facedown encounter card.\n<hr />\n[star] <b>Boost</b>: Put Badoon Grunt into play engaged with you.",
+		"text": "<b>Forced Response</b>: After Badoon Grunt engages you, if there are no other minions engaged with you, deal yourself 1 facedown encounter card.\n<hr />\n[star] <b>Boost</b>: Put Badoon Grunt into play engaged with you.",
 		"traits": "Badoon.",
 		"type_code": "minion"
 	},
@@ -1526,7 +1526,7 @@
 		"quantity": 1,
 		"set_code": "galactic_artifacts",
 		"set_position": 1,
-		"text": "Attach to the enemy with the lowest ATK.\n<b>Hero Action:</b> Spend [physical][physical][physical] resources → discard this card.",
+		"text": "Attach to the enemy with the lowest ATK.\n<b>Hero Action</b>: Spend [physical][physical][physical] resources → discard this card.",
 		"traits": "Artifact.",
 		"type_code": "attachment"
 	},
@@ -1543,7 +1543,7 @@
 		"quantity": 1,
 		"set_code": "galactic_artifacts",
 		"set_position": 2,
-		"text": "Attach to your identity.\nAttached character gets -1 THW, -1 ATK, and -1 DEF.\n<b>Hero Action:</b> Take 1 damage and spend [mental][mental] resources → discard this card. Any player can do this.",
+		"text": "Attach to your identity.\nAttached character gets -1 THW, -1 ATK, and -1 DEF.\n<b>Hero Action</b>: Take 1 damage and spend [mental][mental] resources → discard this card. Any player can do this.",
 		"traits": "Artifact.",
 		"type_code": "attachment"
 	},
@@ -1560,7 +1560,7 @@
 		"scheme_amplify": 1,
 		"set_code": "galactic_artifacts",
 		"set_position": 3,
-		"text": "Attach to the enemy with the highest SCH.\n<b>Hero Action:</b> Place 2 threat on the main scheme and spend 2 resources → discard this card.",
+		"text": "Attach to the enemy with the highest SCH.\n<b>Hero Action</b>: Place 2 threat on the main scheme and spend 2 resources → discard this card.",
 		"traits": "Artifact.",
 		"type_code": "attachment"
 	},
@@ -1578,7 +1578,7 @@
 		"quantity": 1,
 		"set_code": "galactic_artifacts",
 		"set_position": 4,
-		"text": "Attach to your identity.\n<b>Forced Interrupt:</b> When your turn begins, place 1 poison counter here, the take 1 damage for each poison counter here.\n<b>Hero Action:</b> Spend 3 resources of different types → discard this card. Any player can do this.",
+		"text": "Attach to your identity.\n<b>Forced Interrupt</b>: When your turn begins, place 1 poison counter here, the take 1 damage for each poison counter here.\n<b>Hero Action</b>: Spend 3 resources of different types → discard this card. Any player can do this.",
 		"traits": "Artifact.",
 		"type_code": "attachment"
 	},
@@ -1595,7 +1595,7 @@
 		"scheme_hazard": 1,
 		"set_code": "galactic_artifacts",
 		"set_position": 5,
-		"text": "Attach to the enemy with the lowest SCH.\n<b>Hero Action:</b> Spend [energy][energy][energy] resources → discard this card.",
+		"text": "Attach to the enemy with the lowest SCH.\n<b>Hero Action</b>: Spend [energy][energy][energy] resources → discard this card.",
 		"traits": "Artifact.",
 		"type_code": "attachment"
 	},
@@ -1614,7 +1614,7 @@
 		"scheme_acceleration": 1,
 		"set_code": "galactic_artifacts",
 		"set_position": 6,
-		"text": "Hinder 2[per_hero]. Victory 0.\n<b>When Defeated:</b> The player who defeated this scheme may ready their identity.",
+		"text": "Hinder 2[per_hero]. Victory 0.\n<b>When Defeated</b>: The player who defeated this scheme may ready their identity.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1632,7 +1632,7 @@
 		"scheme_hazard": 1,
 		"set_code": "galactic_artifacts",
 		"set_position": 7,
-		"text": "Hinder 2[per_hero]. Victory 0.\n<b>When Defeated:</b> The player who defeated this scheme may heal 4 damage from their identity.",
+		"text": "Hinder 2[per_hero]. Victory 0.\n<b>When Defeated</b>: The player who defeated this scheme may heal 4 damage from their identity.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1650,7 +1650,7 @@
 		"scheme_amplify": 1,
 		"set_code": "galactic_artifacts",
 		"set_position": 8,
-		"text": "Hinder 2[per_hero]. Victory 0.\n<b>When Defeated:</b> The player who defeated this scheme may draw 2 cards.",
+		"text": "Hinder 2[per_hero]. Victory 0.\n<b>When Defeated</b>: The player who defeated this scheme may draw 2 cards.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1668,7 +1668,7 @@
 		"scheme_acceleration": 1,
 		"set_code": "galactic_artifacts",
 		"set_position": 9,
-		"text": "Hinder 2[per_hero]. Victory 0.\n<b>When Defeated:</b> The player who defeated this scheme may play a card from their hand, reducing its resources cost by 3.",
+		"text": "Hinder 2[per_hero]. Victory 0.\n<b>When Defeated</b>: The player who defeated this scheme may play a card from their hand, reducing its resources cost by 3.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1682,7 +1682,7 @@
 		"quantity": 1,
 		"set_code": "kree_militant",
 		"set_position": 1,
-		"text": "Attach to the enemy with the highest ATK.\nReduce the amount of damage attached character takes from each attack by 1.\n<b>Hero Action:</b> Spend 3 resources of the same type → discard this card.",
+		"text": "Attach to the enemy with the highest ATK.\nReduce the amount of damage attached character takes from each attack by 1.\n<b>Hero Action</b>: Spend 3 resources of the same type → discard this card.",
 		"traits": "Armor.",
 		"type_code": "attachment"
 	},
@@ -1756,7 +1756,7 @@
 		"scheme": 2,
 		"set_code": "menagerie_medley",
 		"set_position": 1,
-		"text": "<b>When Revealed:</b> You are confused. If you are already confused, take 1 damage.\n<hr />\n[star] <b>Boost</b>: Put Psionic Ghost into play engaged with you.",
+		"text": "<b>When Revealed</b>: You are confused. If you are already confused, take 1 damage.\n<hr />\n[star] <b>Boost</b>: Put Psionic Ghost into play engaged with you.",
 		"traits": "Ghost.",
 		"type_code": "minion"
 	},
@@ -1813,7 +1813,7 @@
 		"scheme": 2,
 		"set_code": "space_pirates",
 		"set_position": 1,
-		"text": "Quickstrike.\n[star] <b>Forced Response:</b> After this minion attacks and damages you, remove 1 card at random in your hand from the game.\n<hr />\n[star] <b>Boost</b>: Give the villain 1 additional boost card for this activation.",
+		"text": "Quickstrike.\n[star] <b>Forced Response</b>: After this minion attacks and damages you, remove 1 card at random in your hand from the game.\n<hr />\n[star] <b>Boost</b>: Give the villain 1 additional boost card for this activation.",
 		"traits": "Criminal.",
 		"type_code": "minion"
 	},
@@ -1833,7 +1833,7 @@
 		"scheme": 1,
 		"set_code": "space_pirates",
 		"set_position": 2,
-		"text": "Quickstrike.\n[star] <b>Forced Response:</b> After this minion attacks and damages you, remove the top card of your deck from the game.\n<hr />\n[star] <b>Boost</b>: Give the villain 1 additional boost card for this activation.",
+		"text": "Quickstrike.\n[star] <b>Forced Response</b>: After this minion attacks and damages you, remove the top card of your deck from the game.\n<hr />\n[star] <b>Boost</b>: Give the villain 1 additional boost card for this activation.",
 		"traits": "Criminal.",
 		"type_code": "minion"
 	},
@@ -1864,7 +1864,7 @@
 		"quantity": 2,
 		"set_code": "space_pirates",
 		"set_position": 7,
-		"text": "<b>When Revealed:</b> Discard cards from the top of the encounter deck until a [[Criminal]] minion is discarded. Reveal that minion, then give that minion a tough status card and the villain 1 facedown boost card.",
+		"text": "<b>When Revealed</b>: Discard cards from the top of the encounter deck until a [[Criminal]] minion is discarded. Reveal that minion, then give that minion a tough status card and the villain 1 facedown boost card.",
 		"type_code": "treachery"
 	},
 	{
@@ -1879,7 +1879,7 @@
 		"quantity": 1,
 		"set_code": "ship_command",
 		"set_position": 1,
-		"text": "Permanent. Setup.\nThe first player controls the Milano.\n<i>Piloting</i> - <b>Resource:</b> Exhaust the Milano → generate a [wild] resource for any player.",
+		"text": "Permanent. Setup.\nThe first player controls the Milano.\n<i>Piloting</i> - <b>Resource</b>: Exhaust the Milano → generate a [wild] resource for any player.",
 		"traits": "Aerial. Vehicle.",
 		"type_code": "support"
 	},
@@ -1894,7 +1894,7 @@
 		"quantity": 1,
 		"set_code": "ship_command",
 		"set_position": 2,
-		"text": "Surge.\n<b>Forced Interrupt:</b> When the villain phase ends, deal 1 damage to each player.\n<b>First Player Action:</b> Exhaust the Milano and spend 2 resources of any type → discard this card.",
+		"text": "Surge.\n<b>Forced Interrupt</b>: When the villain phase ends, deal 1 damage to each player.\n<b>First Player Action</b>: Exhaust the Milano and spend 2 resources of any type → discard this card.",
 		"traits": "Aerial. Vehicle.",
 		"type_code": "environment"
 	},
@@ -1912,7 +1912,7 @@
 		"scheme_amplify": 1,
 		"set_code": "ship_command",
 		"set_position": 3,
-		"text": "Hinder 3[per_hero] <i>(When revealed, place 3[per_hero] threat here.)</i>.\n<b>First Player Action:</b> Exhaust the Milano → remove 3 threat from this scheme.",
+		"text": "Hinder 3[per_hero] <i>(When revealed, place 3[per_hero] threat here.)</i>.\n<b>First Player Action</b>: Exhaust the Milano → remove 3 threat from this scheme.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1926,7 +1926,7 @@
 		"quantity": 1,
 		"set_code": "ship_command",
 		"set_position": 4,
-		"text": "Peril. <i>(While you are resolving this card, other players cannot help you.)</i>\n<b>When Revealed:</b> Choose one:\n-Exhaust the Milano.\n-Spend [physical][physical] resources.\n- Stun the first player.",
+		"text": "Peril. <i>(While you are resolving this card, other players cannot help you.)</i>\n<b>When Revealed</b>: Choose one:\n-Exhaust the Milano.\n-Spend [physical][physical] resources.\n- Stun the first player.",
 		"type_code": "treachery"
 	},
 	{
@@ -1940,7 +1940,7 @@
 		"quantity": 1,
 		"set_code": "ship_command",
 		"set_position": 5,
-		"text": "Peril. <i>(While you are resolving this card, other players cannot help you.)</i>\n<b>When Revealed:</b> Choose one:\n-Exhaust the Milano.\n-Spend [mental][mental] resources.\n- Deal 3 damage to the first player.",
+		"text": "Peril. <i>(While you are resolving this card, other players cannot help you.)</i>\n<b>When Revealed</b>: Choose one:\n-Exhaust the Milano.\n-Spend [mental][mental] resources.\n- Deal 3 damage to the first player.",
 		"type_code": "treachery"
 	},
 	{
@@ -1954,7 +1954,7 @@
 		"quantity": 1,
 		"set_code": "ship_command",
 		"set_position": 6,
-		"text": "Peril. <i>(While you are resolving this card, other players cannot help you.)</i>\n<b>When Revealed:</b> Choose one:\n-Exhaust the Milano.\n-Spend [energy][energy] resources.\n- Discard 1 card at random from the first player's hand.",
+		"text": "Peril. <i>(While you are resolving this card, other players cannot help you.)</i>\n<b>When Revealed</b>: Choose one:\n-Exhaust the Milano.\n-Spend [energy][energy] resources.\n- Discard 1 card at random from the first player's hand.",
 		"type_code": "treachery"
 	},
 	{
@@ -1967,7 +1967,7 @@
 		"quantity": 1,
 		"set_code": "ship_command",
 		"set_position": 7,
-		"text": "<b>When Revealed (Alter-Ego):</b> You may exhaust the Milano. If you do not, the villain schemes with +1 SCH.\n<b>When Revealed (Hero):</b> You may exhaust the Milano. If you do not, the villain attacks you with +1 ATK.",
+		"text": "<b>When Revealed (Alter-Ego)</b>: You may exhaust the Milano. If you do not, the villain schemes with +1 SCH.\n<b>When Revealed (Hero)</b>: You may exhaust the Milano. If you do not, the villain attacks you with +1 ATK.",
 		"type_code": "treachery"
 	},
 	{
@@ -1982,7 +1982,7 @@
 		"quantity": 1,
 		"set_code": "power_stone",
 		"set_position": 1,
-		"text": "Setup. Attach to the villain.\nPermanent.\n<b>Forced Response:</b> After a hero or villain deals 3 or more damage to attached character with a single attack, attach Power Stone to the attacking hero or villain.",
+		"text": "Setup. Attach to the villain.\nPermanent.\n<b>Forced Response</b>: After a hero or villain deals 3 or more damage to attached character with a single attack, attach Power Stone to the attacking hero or villain.",
 		"traits": "Infinity Stone.",
 		"type_code": "attachment"
 	},

--- a/pack/gob_encounter.json
+++ b/pack/gob_encounter.json
@@ -16,7 +16,7 @@
 		"scheme": 2,
 		"set_code": "risky_business",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "[star] <b>Forced Interrupt</b>: When Norman Osborn would attack, place 1 infamy counter on Criminal Enterprise instead.\n<b>Forced Interrupt</b>: When Norman Osborn would take any amount of damage, remove that many infamy counters from Criminal Enterprise instead.",
 		"traits": "Businessman. Genius.",
 		"type_code": "villain"
@@ -38,7 +38,7 @@
 		"scheme_star": true,
 		"set_code": "risky_business",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "<b>When Revealed</b>: Deal 3 indirect damage to each player in hero form.\n[star] <b>Forced Interrupt</b>: When Green Goblin would scheme, remove 1 madness counter from State of Madness instead.",
 		"traits": "Goblin.",
 		"type_code": "villain"
@@ -60,7 +60,7 @@
 		"scheme": 2,
 		"set_code": "risky_business",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "II",
 		"text": "[star] <b>Forced Interrupt</b>: When Norman Osborn would attack, place 2 infamy counter on Criminal Enterprise instead.\n<b>Forced Interrupt</b>: When Norman Osborn would take any amount of damage, remove that many infamy counters from Criminal Enterprise instead.",
 		"traits": "Businessman. Genius.",
 		"type_code": "villain"
@@ -82,7 +82,7 @@
 		"scheme_star": true,
 		"set_code": "risky_business",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "II",
 		"text": "<b>When Revealed</b>: Deal 3 indirect damage to each player.\n[star] <b>Forced Interrupt</b>: When Green Goblin would scheme, remove 1 madness counter from State of Madness instead.",
 		"traits": "Goblin.",
 		"type_code": "villain"
@@ -104,7 +104,7 @@
 		"scheme": 3,
 		"set_code": "risky_business",
 		"set_position": 3,
-		"stage": 3,
+		"stage": "III",
 		"text": "[star] <b>Forced Interrupt</b>: When Norman Osborn would attack, place 3 infamy counter on Criminal Enterprise instead.\n<b>Forced Interrupt</b>: When Norman Osborn would take any amount of damage, remove that many infamy counters from Criminal Enterprise instead.",
 		"traits": "Businessman. Genius.",
 		"type_code": "villain"
@@ -126,7 +126,7 @@
 		"scheme_star": true,
 		"set_code": "risky_business",
 		"set_position": 3,
-		"stage": 3,
+		"stage": "III",
 		"text": "<b>When Revealed</b>: Deal 4 damage to each player.\n[star] <b>Forced Interrupt</b>: When Green Goblin would scheme, remove 2 madness counters from State of Madness instead.",
 		"traits": "Goblin.",
 		"type_code": "villain"
@@ -142,7 +142,7 @@
 		"quantity": 1,
 		"set_code": "risky_business",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1A",
 		"text": "<b>Contents</b>: Norman Osborn (I) and Norman Osborn (II). <i>(Norman Osborn (II) and Norman Osborn (III) instead for expert mode.)</i> Risky Business and Standard encounter sets. One modular encounter set <i>(recommended: Goblin Gimmicks)</i>.\n<b>Setup</b>: Put the Criminal Enterprise environment into play. Shuffle the encounter deck. Advance to stage 1B.",
 		"type_code": "main_scheme"
 	},
@@ -160,7 +160,7 @@
 		"quantity": 1,
 		"set_code": "risky_business",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1B",
 		"text": "<b>When Completed</b>: Place 1[per_hero] infamy counters on Criminal Enterprise. Then discard 1 card from each player's deck for each infamy counter on Criminal Enterprise.",
 		"threat": 7,
 		"type_code": "main_scheme"
@@ -177,7 +177,7 @@
 		"quantity": 1,
 		"set_code": "risky_business",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2A",
 		"text": "<b>When Revealed</b>: Advance to stage 2B.",
 		"type_code": "main_scheme"
 	},
@@ -196,7 +196,7 @@
 		"scheme_hazard": 1,
 		"set_code": "risky_business",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2B",
 		"text": "<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 10,
 		"type_code": "main_scheme"
@@ -365,7 +365,7 @@
 		"scheme": 1,
 		"set_code": "mutagen_formula",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "[star] <b>Forced Response</b>: After Green Goblin attacks and damages you, place 1 threat on the main scheme.",
 		"traits": "Goblin.",
 		"type_code": "villain"
@@ -387,7 +387,7 @@
 		"scheme": 2,
 		"set_code": "mutagen_formula",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "II",
 		"text": "<b>When Revealed</b>: Deal 2 encounter cards to each player.\n[star] <b>Forced Response</b>: After Green Goblin attacks and damages you, place 1 threat on the main scheme.",
 		"traits": "Goblin.",
 		"type_code": "villain"
@@ -409,7 +409,7 @@
 		"scheme": 2,
 		"set_code": "mutagen_formula",
 		"set_position": 3,
-		"stage": 3,
+		"stage": "III",
 		"text": "<b>When Revealed</b>: Deal 3 encounter cards to each player.\n[star] <b>Forced Response</b>: After Green Goblin attacks and damages you, place 2 threat on the main scheme.",
 		"traits": "Goblin.",
 		"type_code": "villain"
@@ -425,7 +425,7 @@
 		"quantity": 1,
 		"set_code": "mutagen_formula",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1A",
 		"text": "<b>Contents</b>: Green Goblin (I) and Green Goblin (II). <i>(Green Goblin (II) and Green Goblin (III) instead for expert mode.)</i> Mutagen Formula and Standard encounter sets. One modular encounter set <i>(recommended: Goblin Gimmicks)</i>.\n<b>Setup</b>: Put a Goblin Thrall minion into play engaged with each player. Shuffle the encounter deck. Advance to stage 1B.",
 		"type_code": "main_scheme"
 	},
@@ -443,7 +443,7 @@
 		"quantity": 1,
 		"set_code": "mutagen_formula",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1B",
 		"text": "<b>When Completed</b>: In player order, each player not engaged with a [[Goblin]] minion must discard 3 cards from the encounter deck and put the first [[Goblin]] minion they discarded this way into play engaged with them.",
 		"threat": 7,
 		"type_code": "main_scheme"
@@ -460,7 +460,7 @@
 		"quantity": 1,
 		"set_code": "mutagen_formula",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2A",
 		"text": "<b>When Revealed</b>: Advance to stage 2B.",
 		"type_code": "main_scheme"
 	},
@@ -479,7 +479,7 @@
 		"quantity": 1,
 		"set_code": "mutagen_formula",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2B",
 		"text": "X is equal to the number of [[Goblin]] enemies (including Green Goblin) in play.\n<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 11,
 		"type_code": "main_scheme"

--- a/pack/hood_encounter.json
+++ b/pack/hood_encounter.json
@@ -16,8 +16,8 @@
 		"scheme": 1,
 		"set_code": "the_hood",
 		"set_position": 1,
-		"stage": 1,
-		"text": "<i>Foul Play</i> - <b>Special:</b> Discard the top card of the encounter deck. If that card does not belong to The Hood encounter set, deal it to yourself as a facedown encounter card.",
+		"stage": "I",
+		"text": "<i>Foul Play</i> - <b>Special</b>: Discard the top card of the encounter deck. If that card does not belong to The Hood encounter set, deal it to yourself as a facedown encounter card.",
 		"traits": "Criminal.",
 		"type_code": "villain"
 	},
@@ -37,8 +37,8 @@
 		"scheme": 2,
 		"set_code": "the_hood",
 		"set_position": 2,
-		"stage": 2,
-		"text": "<b>When Revealed:</b> Choose 1 set-aside modular encounter set at random, then shuffle it into the encounter deck.\n<i>Foul Play</i> - <b>Special:</b> Discard the top 2 cards of the encounter deck. Deal the first card discarded this way that does not belong to The Hood encounter set to yourself as a facedown encounter card.",
+		"stage": "II",
+		"text": "<b>When Revealed</b>: Choose 1 set-aside modular encounter set at random, then shuffle it into the encounter deck.\n<i>Foul Play</i> - <b>Special</b>: Discard the top 2 cards of the encounter deck. Deal the first card discarded this way that does not belong to The Hood encounter set to yourself as a facedown encounter card.",
 		"traits": "Criminal.",
 		"type_code": "villain"
 	},
@@ -58,8 +58,8 @@
 		"scheme": 3,
 		"set_code": "the_hood",
 		"set_position": 3,
-		"stage": 3,
-		"text": "<b>When Revealed:</b> Choose 1 set-aside modular encounter set at random, then shuffle it into the encounter deck.\n<i>Foul Play</i> - <b>Special:</b> Discard the top 2 cards of the encounter deck. Deal each card discarded this way that does not belong to The Hood encounter set to yourself as a facedown encounter card.",
+		"stage": "III",
+		"text": "<b>When Revealed</b>: Choose 1 set-aside modular encounter set at random, then shuffle it into the encounter deck.\n<i>Foul Play</i> - <b>Special</b>: Discard the top 2 cards of the encounter deck. Deal each card discarded this way that does not belong to The Hood encounter set to yourself as a facedown encounter card.",
 		"traits": "Criminal.",
 		"type_code": "villain"
 	},
@@ -74,8 +74,8 @@
 		"quantity": 1,
 		"set_code": "the_hood",
 		"set_position": 4,
-		"stage": 1,
-		"text": "<b>Contents:</b> The Hood (I) and The Hood (II). <i>(The Hood (II) and The Hood(III) instead for expert mode.)</i> The Hood and Standard encounter sets.\n<b>Setup:</b> Choose 7 modular encounter sets and set them aside (you may choose randomly). Choose 1 of those sets at random, then shuffle it intro the encounter deck.",
+		"stage": "1A",
+		"text": "<b>Contents</b>: The Hood (I) and The Hood (II). <i>(The Hood (II) and The Hood(III) instead for expert mode.)</i> The Hood and Standard encounter sets.\n<b>Setup</b>: Choose 7 modular encounter sets and set them aside (you may choose randomly). Choose 1 of those sets at random, then shuffle it intro the encounter deck.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -92,8 +92,8 @@
 		"quantity": 1,
 		"set_code": "the_hood",
 		"set_position": 4,
-		"stage": 1,
-		"text": "<b>When Revealed:</b> Each player must resolve The Hood's \"Foul Play\" ability in player order.",
+		"stage": "1B",
+		"text": "<b>When Revealed</b>: Each player must resolve The Hood's \"Foul Play\" ability in player order.",
 		"threat": 5,
 		"type_code": "main_scheme"
 	},
@@ -109,8 +109,8 @@
 		"quantity": 1,
 		"set_code": "the_hood",
 		"set_position": 5,
-		"stage": 2,
-		"text": "<b>When Revealed:</b> Choose 1 set-aside modular encounter set at random, then shuffle it into the encounter deck. Place 1 acceleration token on the main scheme.",
+		"stage": "2A",
+		"text": "<b>When Revealed</b>: Choose 1 set-aside modular encounter set at random, then shuffle it into the encounter deck. Place 1 acceleration token on the main scheme.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -126,8 +126,8 @@
 		"quantity": 1,
 		"set_code": "the_hood",
 		"set_position": 5,
-		"stage": 2,
-		"text": "<b>When Revealed:</b> Each player must resolve The Hood's \"Foul Play\" ability in player order. For each player who was not dealt at least 1 facedown encounter card this way, place 2 threat here.",
+		"stage": "2B",
+		"text": "<b>When Revealed</b>: Each player must resolve The Hood's \"Foul Play\" ability in player order. For each player who was not dealt at least 1 facedown encounter card this way, place 2 threat here.",
 		"threat": 8,
 		"type_code": "main_scheme"
 	},
@@ -143,8 +143,8 @@
 		"quantity": 1,
 		"set_code": "the_hood",
 		"set_position": 6,
-		"stage": 3,
-		"text": "<b>When Revealed:</b> Choose 1 set-aside modular encounter set at random, then shuffle it into the encounter deck. Place 1 acceleration token on the main scheme. Each player must resolve The Hood's \"Foul Play\" ability in player order.",
+		"stage": "3A",
+		"text": "<b>When Revealed</b>: Choose 1 set-aside modular encounter set at random, then shuffle it into the encounter deck. Place 1 acceleration token on the main scheme. Each player must resolve The Hood's \"Foul Play\" ability in player order.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -161,7 +161,7 @@
 		"quantity": 1,
 		"set_code": "the_hood",
 		"set_position": 6,
-		"stage": 3,
+		"stage": "3B",
 		"text": "[star] <b>Forced Response</b>: After resolving step one of the villain phase, each player must resolve The Hood's <i>\"Foul Play\"</i> ability in player order.\n<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 10,
 		"type_code": "main_scheme"
@@ -177,7 +177,7 @@
 		"quantity": 1,
 		"set_code": "the_hood",
 		"set_position": 7,
-		"text": "Attach to your identity.\n<b>Forced Response:</b> After The Hood activates against you, resolve his \"Foul Play\" ability\n<b>Alter-Ego Action:</b> Exhaust your identity and place 2 threat on the main scheme → discard this card.",
+		"text": "Attach to your identity.\n<b>Forced Response</b>: After The Hood activates against you, resolve his \"Foul Play\" ability\n<b>Alter-Ego Action</b>: Exhaust your identity and place 2 threat on the main scheme → discard this card.",
 		"type_code": "attachment"
 	},
 	{
@@ -190,7 +190,7 @@
 		"quantity": 1,
 		"set_code": "the_hood",
 		"set_position": 8,
-		"text": "Attach to The Hood.\nThe Hood gains retaliate 1 and steady. <i>(Steady characters require 2 status cards of the same type to be stunned or confused.)</i>\n<b>Hero Action:</b> Spend [energy][mental][physical] resources → discard this card.",
+		"text": "Attach to The Hood.\nThe Hood gains retaliate 1 and steady. <i>(Steady characters require 2 status cards of the same type to be stunned or confused.)</i>\n<b>Hero Action</b>: Spend [energy][mental][physical] resources → discard this card.",
 		"traits": "Armor.",
 		"type_code": "attachment"
 	},
@@ -207,7 +207,7 @@
 		"scheme": 1,
 		"set_code": "the_hood",
 		"set_position": 9,
-		"text": "Attach to The Hood.\n<b>Hero Action:</b> Spend [mental][physical] resources → discard this card.\n<hr />\n[star] <b>Boost</b>: Reveal this card.",
+		"text": "Attach to The Hood.\n<b>Hero Action</b>: Spend [mental][physical] resources → discard this card.\n<hr />\n[star] <b>Boost</b>: Reveal this card.",
 		"traits": "Weapon.",
 		"type_code": "attachment"
 	},
@@ -226,7 +226,7 @@
 		"scheme": 1,
 		"set_code": "the_hood",
 		"set_position": 11,
-		"text": "Guard.\n<b>When Revealed:</b> Resolve The Hood's \"Foul Play\" ability.\n<b>When Defeated:</b> The defeating player must resolve The Hood's \"Foul Play\" ability.",
+		"text": "Guard.\n<b>When Revealed</b>: Resolve The Hood's \"Foul Play\" ability.\n<b>When Defeated</b>: The defeating player must resolve The Hood's \"Foul Play\" ability.",
 		"traits": "Criminal. Masters of Evil.",
 		"type_code": "minion"
 	},
@@ -243,7 +243,7 @@
 		"quantity": 1,
 		"set_code": "the_hood",
 		"set_position": 12,
-		"text": "Hinder 2[per_hero]. <i>(When revealed, place 2[per_hero] threat here.)</i>\n<b>Forced Interrupt:</b> When the villain phase begins, each player must resolve The Hood's \"Foul Play\" ability in player order.",
+		"text": "Hinder 2[per_hero]. <i>(When revealed, place 2[per_hero] threat here.)</i>\n<b>Forced Interrupt</b>: When the villain phase begins, each player must resolve The Hood's \"Foul Play\" ability in player order.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -272,7 +272,7 @@
 		"quantity": 3,
 		"set_code": "the_hood",
 		"set_position": 14,
-		"text": "<b>When Revealed (Alter-Ego):</b> The Hood schemes. Resolve The Hood's \"Foul Play\" ability.\n<b>When Revealed (Hero):</b> The Hood attacks you. Resolve The Hood's \"Foul Play\" ability.",
+		"text": "<b>When Revealed (Alter-Ego)</b>: The Hood schemes. Resolve The Hood's \"Foul Play\" ability.\n<b>When Revealed (Hero)</b>: The Hood attacks you. Resolve The Hood's \"Foul Play\" ability.",
 		"type_code": "treachery"
 	},
 	{
@@ -288,7 +288,7 @@
 		"quantity": 1,
 		"set_code": "beasty_boys",
 		"set_position": 1,
-		"text": "<b>Forced Interrupt:</b> When a stunned or confused friendly character would take any amount of damage, increase that amount by 1.",
+		"text": "<b>Forced Interrupt</b>: When a stunned or confused friendly character would take any amount of damage, increase that amount by 1.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -307,7 +307,7 @@
 		"scheme": 1,
 		"set_code": "beasty_boys",
 		"set_position": 2,
-		"text": "Quickstrike.\n[star] <b>Forced Response</b>: After Griffin attacks and damages a character, stun that character.\n<b>When Defeated:</b> If there is a stunned friendly character in play, shuffle Griffin into the encounter deck.",
+		"text": "Quickstrike.\n[star] <b>Forced Response</b>: After Griffin attacks and damages a character, stun that character.\n<b>When Defeated</b>: If there is a stunned friendly character in play, shuffle Griffin into the encounter deck.",
 		"traits": "Brute. Masters of Evil.",
 		"type_code": "minion"
 	},
@@ -327,7 +327,7 @@
 		"scheme": 2,
 		"set_code": "beasty_boys",
 		"set_position": 3,
-		"text": "Mandrill gains retaliate X, where X is equal to the number of confused characters <i>(friendly or enemy)</i> in play.\n<b>When Revealed:</b> Confuse each character you control.",
+		"text": "Mandrill gains retaliate X, where X is equal to the number of confused characters <i>(friendly or enemy)</i> in play.\n<b>When Revealed</b>: Confuse each character you control.",
 		"traits": "Brute. Crossfire's Crew.",
 		"type_code": "minion"
 	},
@@ -452,7 +452,7 @@
 		"scheme_hazard": 1,
 		"set_code": "crossfire_crew",
 		"set_position": 1,
-		"text": "<b>When Revealed:</b> Deal 1 damage to the friendly character with the fewest remaining hit points. If that character is defeated this way, repeat this effect.\n<hr />\n[star] <b>Boost</b>: Resolve this card's \"<b>When Revealed</b>\" ability.",
+		"text": "<b>When Revealed</b>: Deal 1 damage to the friendly character with the fewest remaining hit points. If that character is defeated this way, repeat this effect.\n<hr />\n[star] <b>Boost</b>: Resolve this card's \"<b>When Revealed</b>\" ability.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -472,7 +472,7 @@
 		"scheme": 2,
 		"set_code": "crossfire_crew",
 		"set_position": 2,
-		"text": "[star] <b>Forced Interrupt:</b> When Controller's attack would deal any amount of damage to a character, increase that amount by that character's ATK.",
+		"text": "[star] <b>Forced Interrupt</b>: When Controller's attack would deal any amount of damage to a character, increase that amount by that character's ATK.",
 		"traits": "Brute. Crossfire's Crew.",
 		"type_code": "minion"
 	},
@@ -492,7 +492,7 @@
 		"scheme": 1,
 		"set_code": "crossfire_crew",
 		"set_position": 3,
-		"text": "<b>When Revealed:</b> Exhaust each ally you control. Place 1 threat on the main scheme for each ally exhausted this way.\n<hr />\n[star] <b>Boost</b>: Choose and exhaust a character you control.",
+		"text": "<b>When Revealed</b>: Exhaust each ally you control. Place 1 threat on the main scheme for each ally exhausted this way.\n<hr />\n[star] <b>Boost</b>: Choose and exhaust a character you control.",
 		"traits": "Criminal. Crossfire's Crew.",
 		"type_code": "minion"
 	},
@@ -548,7 +548,7 @@
 		"quantity": 1,
 		"set_code": "crossfire_crew",
 		"set_position": 6,
-		"text": "<b>When Revealed:</b> Discard cards from the top of the encounter deck until a [[Crossfire's Crew]] minion is discarded. Reveal that minion. Take indirect damage equal to the number of [[Crossfire's Crew]] minions in play.",
+		"text": "<b>When Revealed</b>: Discard cards from the top of the encounter deck until a [[Crossfire's Crew]] minion is discarded. Reveal that minion. Take indirect damage equal to the number of [[Crossfire's Crew]] minions in play.",
 		"type_code": "treachery"
 	},
 	{
@@ -620,7 +620,7 @@
 		"quantity": 1,
 		"set_code": "mister_hyde",
 		"set_position": 1,
-		"text": "<b>When Revealed:</b> Search the encounter deck and discard pile for Mister Hyde and reveal him. <i>(Shuffle.)</i>\n<b>Forced Interrupt:</b> When a [[Brute]] enemy would take any amount of damage, remove that much threat from this scheme instead.",
+		"text": "<b>When Revealed</b>: Search the encounter deck and discard pile for Mister Hyde and reveal him. <i>(Shuffle.)</i>\n<b>Forced Interrupt</b>: When a [[Brute]] enemy would take any amount of damage, remove that much threat from this scheme instead.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -638,7 +638,7 @@
 		"scheme": 3,
 		"set_code": "mister_hyde",
 		"set_position": 2,
-		"text": "<b>When Revealed:</b> If Mister Hyde is in play, discard this card → Mister Hyde attacks you with +2 ATK. That attack gains overkill.\n<b>When Defeated:</b> Search the encounter deck and discard pile for Mister Hyde and put him into play engaged with the player who was engaged with Calvin Zabo.",
+		"text": "<b>When Revealed</b>: If Mister Hyde is in play, discard this card → Mister Hyde attacks you with +2 ATK. That attack gains overkill.\n<b>When Defeated</b>: Search the encounter deck and discard pile for Mister Hyde and put him into play engaged with the player who was engaged with Calvin Zabo.",
 		"traits": "Elite. Masters of Evil.",
 		"type_code": "minion"
 	},
@@ -658,7 +658,7 @@
 		"scheme": 1,
 		"set_code": "mister_hyde",
 		"set_position": 3,
-		"text": "<b>When Revealed:</b> If Calvin Zabo is engaged with a player, discard Calvin Zabo → Mister Hyde engages that player. Give Mister Hyde a tough status card and deal 1 damage to each hero and ally in play.",
+		"text": "<b>When Revealed</b>: If Calvin Zabo is engaged with a player, discard Calvin Zabo → Mister Hyde engages that player. Give Mister Hyde a tough status card and deal 1 damage to each hero and ally in play.",
 		"traits": "Brute. Elite. Masters of Evil.",
 		"type_code": "minion"
 	},
@@ -673,7 +673,7 @@
 		"quantity": 1,
 		"set_code": "mister_hyde",
 		"set_position": 4,
-		"text": "<b>When Revealed:</b> If Calvin Zabo is in play, he schemes with +3 SCH, then he takes 4 damage. If Mister Hyde is in play, give him a tough status card and he attacks you <i>(even if you are in alter-ego form)</i>. If neither is in play, this card gains surge.",
+		"text": "<b>When Revealed</b>: If Calvin Zabo is in play, he schemes with +3 SCH, then he takes 4 damage. If Mister Hyde is in play, give him a tough status card and he attacks you <i>(even if you are in alter-ego form)</i>. If neither is in play, this card gains surge.",
 		"type_code": "treachery"
 	},
 	{
@@ -722,7 +722,7 @@
 		"quantity": 2,
 		"set_code": "ransacked_armory",
 		"set_position": 3,
-		"text": "Attach to the minion with the most remaining hit points. If you cannot, this card gains surge.\n<b>Forced Interrupt:</b> When attached minion would take any amount of damage from an attack, discard the top card of the encounter deck. Reduce damage from that attack by the number of boost icons ([boost]) discarded this way.",
+		"text": "Attach to the minion with the most remaining hit points. If you cannot, this card gains surge.\n<b>Forced Interrupt</b>: When attached minion would take any amount of damage from an attack, discard the top card of the encounter deck. Reduce damage from that attack by the number of boost icons ([boost]) discarded this way.",
 		"traits": "Item. Tech.",
 		"type_code": "attachment"
 	},
@@ -816,7 +816,7 @@
 		"scheme": 2,
 		"set_code": "sinister_syndicate",
 		"set_position": 3,
-		"text": "[star] <b>Forced Response:</b> After Boomerang attacks you, deal 1 damage to each ally you control.\n<hr />\n[star] <b>Boost</b>: Deal 2 damage to an ally you control.",
+		"text": "[star] <b>Forced Response</b>: After Boomerang attacks you, deal 1 damage to each ally you control.\n<hr />\n[star] <b>Boost</b>: Deal 2 damage to an ally you control.",
 		"traits": "Criminal. Masters of Evil.",
 		"type_code": "minion"
 	},
@@ -835,7 +835,7 @@
 		"scheme": 1,
 		"set_code": "sinister_syndicate",
 		"set_position": 4,
-		"text": "<b>Forced Response:</b> After Shocker is attacked, stun the attacking character.\n<hr />\n[star] <b>Boost</b>: Stun the character you control with the highest ATK value.",
+		"text": "<b>Forced Response</b>: After Shocker is attacked, stun the attacking character.\n<hr />\n[star] <b>Boost</b>: Stun the character you control with the highest ATK value.",
 		"traits": "Criminal. Masters of Evil.",
 		"type_code": "minion"
 	},
@@ -854,7 +854,7 @@
 		"scheme": 1,
 		"set_code": "sinister_syndicate",
 		"set_position": 5,
-		"text": "<b>Forced Interrupt:</b> When a character attacks Speed Demon, Speed Demon attacks that character. <i>(Resolve Speed Demon's attack first.)</i>\n<hr />\n[star] <b>Boost</b>: Discard the lowest-cost support you control.",
+		"text": "<b>Forced Interrupt</b>: When a character attacks Speed Demon, Speed Demon attacks that character. <i>(Resolve Speed Demon's attack first.)</i>\n<hr />\n[star] <b>Boost</b>: Discard the lowest-cost support you control.",
 		"traits": "Criminal.",
 		"type_code": "minion"
 	},
@@ -889,7 +889,7 @@
 		"quantity": 1,
 		"set_code": "sinister_syndicate",
 		"set_position": 7,
-		"text": "<b>When Revealed (Alter-Ego):</b> Each [[Criminal]] enemy in play schemes. If no enemy schemed this way, this card gains surge.\n<b>When Revealed (Hero):</b> Each [[Criminal]] enemy in play attacks you. If no enemy attacked this way, this card gains surge.",
+		"text": "<b>When Revealed (Alter-Ego)</b>: Each [[Criminal]] enemy in play schemes. If no enemy schemed this way, this card gains surge.\n<b>When Revealed (Hero)</b>: Each [[Criminal]] enemy in play attacks you. If no enemy attacked this way, this card gains surge.",
 		"type_code": "treachery"
 	},
 	{
@@ -949,7 +949,7 @@
 		"quantity": 1,
 		"set_code": "standard_ii",
 		"set_position": 4,
-		"text": "<b>When Revealed (Alter-Ego):</b> Discard the top 7 cards from the encounter deck. Put the first minion discarded this way into play engaged with you.\n<b>When Revealed (Hero):</b> The villain and each minion engaged with you attacks you. This card gains surge.",
+		"text": "<b>When Revealed (Alter-Ego)</b>: Discard the top 7 cards from the encounter deck. Put the first minion discarded this way into play engaged with you.\n<b>When Revealed (Hero)</b>: The villain and each minion engaged with you attacks you. This card gains surge.",
 		"type_code": "treachery"
 	},
 	{
@@ -1011,7 +1011,7 @@
 		"scheme_acceleration": 1,
 		"set_code": "state_of_emergency",
 		"set_position": 1,
-		"text": "<b>When Revealed:</b> Discard the highest-cost card from your hand.",
+		"text": "<b>When Revealed</b>: Discard the highest-cost card from your hand.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1028,7 +1028,7 @@
 		"scheme_acceleration": 1,
 		"set_code": "state_of_emergency",
 		"set_position": 2,
-		"text": "<b>When Revealed:</b> Take 3 indirect damage.",
+		"text": "<b>When Revealed</b>: Take 3 indirect damage.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1045,7 +1045,7 @@
 		"scheme_acceleration": 1,
 		"set_code": "state_of_emergency",
 		"set_position": 3,
-		"text": "<b>When Revealed:</b> Discard the lowest-cost card you control.",
+		"text": "<b>When Revealed</b>: Discard the lowest-cost card you control.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1061,7 +1061,7 @@
 		"scheme_acceleration": 1,
 		"set_code": "state_of_emergency",
 		"set_position": 4,
-		"text": "<b>When Revealed:</b> Discard cards from the top of the encounter deck until a minion is discard. Put that minion into play engaged with you.",
+		"text": "<b>When Revealed</b>: Discard cards from the top of the encounter deck until a minion is discard. Put that minion into play engaged with you.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1075,7 +1075,7 @@
 		"quantity": 2,
 		"set_code": "state_of_emergency",
 		"set_position": 5,
-		"text": "<b>When Revealed:</b> Resolve each \"<b>When Revealed</b>\" ability on each side scheme in play. If no \"<b>When Revealed</b>\" ability was resolved this way, place 2 threat on each scheme.\n<hr />\n[star] <b>Boost</b>: Resolve this card's \"<b>When Revealed</b>\" ability.",
+		"text": "<b>When Revealed</b>: Resolve each \"<b>When Revealed</b>\" ability on each side scheme in play. If no \"<b>When Revealed</b>\" ability was resolved this way, place 2 threat on each scheme.\n<hr />\n[star] <b>Boost</b>: Resolve this card's \"<b>When Revealed</b>\" ability.",
 		"type_code": "treachery"
 	},
 	{
@@ -1089,7 +1089,7 @@
 		"quantity": 1,
 		"set_code": "streets_of_mayhem",
 		"set_position": 1,
-		"text": "Surge.<b>When Revealed:</b> Discard each other [[Setting]] environment in play.\nEach character in play gets +1 ATK.",
+		"text": "Surge.<b>When Revealed</b>: Discard each other [[Setting]] environment in play.\nEach character in play gets +1 ATK.",
 		"traits": "Location. Setting.",
 		"type_code": "environment"
 	},
@@ -1104,7 +1104,7 @@
 		"quantity": 1,
 		"set_code": "streets_of_mayhem",
 		"set_position": 2,
-		"text": "Surge.<b>When Revealed:</b> Discard each other [[Setting]] environment in play.\nEach enemy in play gains 1 acceleration icon ([acceleration]).\nEach hero and ally in play gets +1 THW.",
+		"text": "Surge.<b>When Revealed</b>: Discard each other [[Setting]] environment in play.\nEach enemy in play gains 1 acceleration icon ([acceleration]).\nEach hero and ally in play gets +1 THW.",
 		"traits": "Location. Setting.",
 		"type_code": "environment"
 	},
@@ -1120,7 +1120,7 @@
 		"quantity": 1,
 		"set_code": "streets_of_mayhem",
 		"set_position": 3,
-		"text": "Surge.<b>When Revealed:</b> Discard each other [[Setting]] environment in play.\nEach character in play gains retaliate 1.",
+		"text": "Surge.<b>When Revealed</b>: Discard each other [[Setting]] environment in play.\nEach character in play gains retaliate 1.",
 		"traits": "Location. Setting.",
 		"type_code": "environment"
 	},
@@ -1135,7 +1135,7 @@
 		"quantity": 1,
 		"set_code": "streets_of_mayhem",
 		"set_position": 4,
-		"text": "Surge.<b>When Revealed:</b> Discard each other [[Setting]] environment in play.\nEach character in play gains steady. <i>(Steady characters require 2 status cards of the same type to be stunned or confused.)</i>",
+		"text": "Surge.<b>When Revealed</b>: Discard each other [[Setting]] environment in play.\nEach character in play gains steady. <i>(Steady characters require 2 status cards of the same type to be stunned or confused.)</i>",
 		"traits": "Location. Setting.",
 		"type_code": "environment"
 	},
@@ -1251,7 +1251,7 @@
 		"quantity": 1,
 		"set_code": "wrecking_crew_modular",
 		"set_position": 6,
-		"text": "<b>When Revealed:</b> Each [[Elite]] minion in play activates against the player it is engaged with. If no minion activated this way, this card gains surge.\n<hr />\n[star] <b>Boost</b>: For each [[Elite]] minion in play, this card gets +1 boost icon ([boost]) for this activation.",
+		"text": "<b>When Revealed</b>: Each [[Elite]] minion in play activates against the player it is engaged with. If no minion activated this way, this card gains surge.\n<hr />\n[star] <b>Boost</b>: For each [[Elite]] minion in play, this card gets +1 boost icon ([boost]) for this activation.",
 		"type_code": "treachery"
 	},
 	{
@@ -1266,7 +1266,7 @@
 		"quantity": 1,
 		"set_code": "wrecking_crew_modular",
 		"set_position": 7,
-		"text": "<b>When Revealed:</b> Give each [[Brute]] enemy in play a tough status card. If no tough status card was given this way, discard cards from the top of the encounter deck until a [[Brute]] minion is discarded and reveal that minion.",
+		"text": "<b>When Revealed</b>: Give each [[Brute]] enemy in play a tough status card. If no tough status card was given this way, discard cards from the top of the encounter deck until a [[Brute]] minion is discarded and reveal that minion.",
 		"type_code": "treachery"
 	}
 ]

--- a/pack/mojo_encounter.json
+++ b/pack/mojo_encounter.json
@@ -17,7 +17,7 @@
 		"scheme": 1,
 		"set_code": "magog",
 		"set_position": 1,
-		"stage": null,
+		"stage": "A",
 		"text": "[star] <b>Forced Response</b>: After MaGog attacks and damages a character, place 1 ratings counter on The Champion.\n<b>Forced Interrupt</b>: When MaGog would be defeated, reset his hit points to 10[per_hero] instead. Place 3[per_hero] ratings counters on The Challengers and deal each player 1 facedown encounter card.",
 		"traits": "Brute.",
 		"type_code": "villain"
@@ -40,7 +40,7 @@
 		"scheme": 1,
 		"set_code": "magog",
 		"set_position": 1,
-		"stage": null,
+		"stage": "B",
 		"text": "[star] <b>Forced Response</b>: After MaGog attacks and damages a character, place 2 ratings counters on The Champion.\n<b>Forced Interrupt</b>: When MaGog would be defeated, reset his hit points to 10[per_hero] instead. Place 2[per_hero] ratings counters on The Challengers and deal each player 1 facedown encounter card.",
 		"traits": "Brute.",
 		"type_code": "villain"
@@ -57,7 +57,7 @@
 		"quantity": 1,
 		"set_code": "magog",
 		"set_position": 2,
-		"stage": 1,
+		"stage": "1A",
 		"text": "<b>Contents</b>: MaGog (A) <i>(MaGog (B) instead for expert mode)</i>. MaGog and Standard encounter sets. One modular encounter set <i>(1 random modular set from the</i> MojoMania <i>scenario pack)</i>.\n<b>Setup</b>: Put The Champion environment card and The Challengers environment card into play, each with its [[BOOING CROWD]] side faceup.",
 		"threat": null,
 		"type_code": "main_scheme"
@@ -76,7 +76,7 @@
 		"quantity": 1,
 		"set_code": "magog",
 		"set_position": 2,
-		"stage": 1,
+		"stage": "1B",
 		"text": "The players cannot win the game unless they wow the crowd as The Challengers.\n[star] <b>Forced Interrupt</b>: When this scheme would be completed, place 2[per_hero] ratings counters on The Champion and remove all threat from here instead.",
 		"threat": 6,
 		"threat_star": true,
@@ -283,7 +283,7 @@
 		"scheme": 1,
 		"set_code": "spiral",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "Spiral cannot take damage or be stunned. Threat cannot be removed from the main scheme.\n[star] <b>Forced Interrupt</b>: When Spiral would attack, she schemes instead.",
 		"traits": "Escaped. Mystic.",
 		"type_code": "villain"
@@ -307,7 +307,7 @@
 		"scheme_star": true,
 		"set_code": "spiral",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "If there are at least 3[per_hero] teleport counters here, remove all of them and flip Spiral.\n[star] <b>Forced Response</b>: After Spiral activates, place 1 teleport counter here.",
 		"traits": "Cornered. Mystic.",
 		"type_code": "villain"
@@ -330,7 +330,7 @@
 		"scheme": 2,
 		"set_code": "spiral",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "II",
 		"text": "Spiral cannot take damage or be stunned. Threat cannot be removed from the main scheme.\n[star] <b>Forced Interrupt</b>: When Spiral would attack, she schemes instead.",
 		"traits": "Escaped. Mystic.",
 		"type_code": "villain"
@@ -354,7 +354,7 @@
 		"scheme_star": true,
 		"set_code": "spiral",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "II",
 		"text": "If there are at least 2[per_hero] teleport counters here, remove all of them and flip Spiral.\n[star] <b>Forced Response</b>: After Spiral activates, place 1 teleport counter here.",
 		"traits": "Cornered. Mystic.",
 		"type_code": "villain"
@@ -377,7 +377,7 @@
 		"scheme": 2,
 		"set_code": "spiral",
 		"set_position": 3,
-		"stage": 3,
+		"stage": "III",
 		"text": "Spiral cannot take damage or be stunned. Threat cannot be removed from the main scheme.\n[star] <b>Forced Interrupt</b>: When Spiral would attack, she schemes instead.",
 		"traits": "Escaped. Mystic.",
 		"type_code": "villain"
@@ -400,7 +400,7 @@
 		"scheme": 2,
 		"set_code": "spiral",
 		"set_position": 3,
-		"stage": 3,
+		"stage": "III",
 		"text": "If there are at least 3[per_hero] teleport counters here, remove all of them and flip Spiral.\n<b>When Revealed</b>: Spiral attacks each player in player order <i>(even in alter-ego form)</i>.\n[star] <b>Forced Response</b>: After Spiral activates, place 1 teleport counter here.",
 		"traits": "Cornered. Mystic.",
 		"type_code": "villain"
@@ -417,7 +417,7 @@
 		"quantity": 1,
 		"set_code": "spiral",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1A",
 		"text": "<b>Contents</b>: Spiral (I) and Spiral (II) <i>(Spiral (II) and Spiral (III) instead for expert mode)</i>. Spiral and Standard encounter sets. Three modular encounter sets from the MojoMania scenario pack.\n<b>Setup</b>: Put The Search for Spiral side scheme and 1 random [[SHOW]] environment into play. Shuffle each other [[SHOW]] environment together with the Cornered! treachery to create the show deck. <i>(See rulebook p. 11)</i>. Flip Spiral to her [[ESCAPED]] side.",
 		"threat": null,
 		"type_code": "main_scheme"
@@ -436,7 +436,7 @@
 		"quantity": 1,
 		"set_code": "spiral",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1B",
 		"text": "<b>Forced Interrupt</b>: When a [[SHOW]] environment would be discarded, place it on the bottom of the show deck instead.\n<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 15,
 		"type_code": "main_scheme"
@@ -550,7 +550,7 @@
 		"scheme": 2,
 		"set_code": "mojo",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "<b>Forced Response (Hero)</b>: After your turn ends, discard the top 3 cards of the encounter deck. Place 1 threat on your hero for each card discarded this way that does not belong to the Mojo encounter set.",
 		"traits": "Spineless.",
 		"type_code": "villain"
@@ -571,7 +571,7 @@
 		"scheme": 3,
 		"set_code": "mojo",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "II",
 		"text": "<b>When Revealed</b>: Place 2 threat on each friendly character.\n<b>Forced Response (Hero)</b>: After your turn ends, discard the top 4 cards of the encounter deck. Place 1 threat on your hero for each card discarded this way that does not belong to the Mojo encounter set.",
 		"traits": "Spineless.",
 		"type_code": "villain"
@@ -592,7 +592,7 @@
 		"scheme": 4,
 		"set_code": "mojo",
 		"set_position": 3,
-		"stage": 3,
+		"stage": "III",
 		"text": "<b>When Revealed</b>: Place 3 threat on each friendly character.\n<b>Forced Response (Hero)</b>: After your turn ends, discard the top 5 cards of the encounter deck. Place 1 threat on your hero for each card discarded this way that does not belong to the Mojo encounter set.",
 		"traits": "Spineless.",
 		"type_code": "villain"
@@ -609,7 +609,7 @@
 		"quantity": 1,
 		"set_code": "mojo",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1A",
 		"text": "<b>Contents</b>: Mojo (I) and Mojo (II) <i>(Mojo (II) and Mojo (III) instead for expert mode)</i>. Mojo and Standard encounter sets.\n<b>Setup</b>: Choose 1 modular set, plus 1[per_hero] additional modular sets, from the MojoMania scenario pack and set them aside. Put the Wheel of Genres environment into play, [[SPINNING]] side faceup.",
 		"threat": null,
 		"type_code": "main_scheme"
@@ -627,7 +627,7 @@
 		"quantity": 1,
 		"set_code": "mojo",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1B",
 		"text": "<b>When Revealed</b>: Choose 1 set-aside encounter set at random, reveal its [[SHOW]] environment and shuffle its remaining cards into the encounter deck.\n<b>Forced Interrupt</b>: When a character flips or leaves play, move all threat from that character to this scheme.\n<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 25,
 		"type_code": "main_scheme"
@@ -1450,7 +1450,7 @@
 		"resource_wild": 1,
 		"set_code": "longshot",
 		"set_position": 1,
-		"text": "[star] Longshot's attacks gain piercing.\nLongshot does not count against your ally limit.\n<b>When Revealed:</b> Put Longshot into play under your control. This card gains surge. This effect cannot be canceled.",
+		"text": "[star] Longshot's attacks gain piercing.\nLongshot does not count against your ally limit.\n<b>When Revealed</b>: Put Longshot into play under your control. This card gains surge. This effect cannot be canceled.",
 		"traits": "X-Men.",
 		"thwart": 2,
 		"thwart_cost": 1,

--- a/pack/mts_encounter.json
+++ b/pack/mts_encounter.json
@@ -178,7 +178,7 @@
 		"scheme_star": true,
 		"set_code": "ebony_maw",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "[star] <b>Forced Interrupt</b>: When Ebony Maw activates against you, remove an invocation counter from each [[Spell]] card in your play area.",
 		"traits": "Black Order. Mystic.",
 		"type_code": "villain"
@@ -200,8 +200,8 @@
 		"scheme_star": true,
 		"set_code": "ebony_maw",
 		"set_position": 2,
-		"stage": 2,
-		"text": "[star] <b>Forced Interrupt</b>: When Ebony Maw activates against you, remove an invocation counter from each [[Spell]] card in your play area.\n<b>When Revealed:</b> Each player discards cards from the top of the encounter deck until they discard a [[Spell]] card and puts that card into play in their play area.",
+		"stage": "II",
+		"text": "[star] <b>Forced Interrupt</b>: When Ebony Maw activates against you, remove an invocation counter from each [[Spell]] card in your play area.\n<b>When Revealed</b>: Each player discards cards from the top of the encounter deck until they discard a [[Spell]] card and puts that card into play in their play area.",
 		"traits": "Black Order. Mystic.",
 		"type_code": "villain"
 	},
@@ -222,8 +222,8 @@
 		"scheme_star": true,
 		"set_code": "ebony_maw",
 		"set_position": 3,
-		"stage": 3,
-		"text": "[star] <b>Forced Interrupt</b>: When Ebony Maw activates against you, remove an invocation counter from each [[Spell]] card in your play area.\n<b>When Revealed:</b> Each player discards cards from the top of the encounter deck until they discard a [[Spell]] card and puts that card into play in their play area.",
+		"stage": "III",
+		"text": "[star] <b>Forced Interrupt</b>: When Ebony Maw activates against you, remove an invocation counter from each [[Spell]] card in your play area.\n<b>When Revealed</b>: Each player discards cards from the top of the encounter deck until they discard a [[Spell]] card and puts that card into play in their play area.",
 		"traits": "Black Order. Mystic.",
 		"type_code": "villain"
 	},
@@ -238,8 +238,8 @@
 		"quantity": 1,
 		"set_code": "ebony_maw",
 		"set_position": 4,
-		"stage": 1,
-		"text": "<b>Contents:</b> Ebony Maw (I) and Ebony Maw (II). <i>(Ebony Maw (II) and Ebony Maw (III) instead for expert mode.)</i> Ebony Maw and Standard encounter sets. Two modular encounter set <i>(Armies of Titan and Black Order).</i>",
+		"stage": "1A",
+		"text": "<b>Contents</b>: Ebony Maw (I) and Ebony Maw (II). <i>(Ebony Maw (II) and Ebony Maw (III) instead for expert mode.)</i> Ebony Maw and Standard encounter sets. Two modular encounter set <i>(Armies of Titan and Black Order).</i>",
 		"type_code": "main_scheme"
 	},
 	{
@@ -255,8 +255,8 @@
 		"quantity": 1,
 		"set_code": "ebony_maw",
 		"set_position": 4,
-		"stage": 1,
-		"text": "<b>When Revealed:</b> Each player discards cards from the top of the encounter deck until they discard a [[Spell]] card and puts that card into play in their play area. Shuffle the encounter discard pile into the encounter deck.",
+		"stage": "1B",
+		"text": "<b>When Revealed</b>: Each player discards cards from the top of the encounter deck until they discard a [[Spell]] card and puts that card into play in their play area. Shuffle the encounter discard pile into the encounter deck.",
 		"threat": 6,
 		"type_code": "main_scheme"
 	},
@@ -271,8 +271,8 @@
 		"quantity": 1,
 		"set_code": "ebony_maw",
 		"set_position": 5,
-		"stage": 2,
-		"text": "<b>When Revealed:</b> Shuffle the encounter discard pile into the encounter deck. Each player discards cards from the top of the encounter deck until they discard a [[Spell]] card and puts that card into play in their play area.",
+		"stage": "2A",
+		"text": "<b>When Revealed</b>: Shuffle the encounter discard pile into the encounter deck. Each player discards cards from the top of the encounter deck until they discard a [[Spell]] card and puts that card into play in their play area.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -289,7 +289,7 @@
 		"quantity": 1,
 		"set_code": "ebony_maw",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2B",
 		"text": "<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 9,
 		"type_code": "main_scheme"
@@ -305,7 +305,7 @@
 		"quantity": 2,
 		"set_code": "ebony_maw",
 		"set_position": 6,
-		"text": "Surge.\nEnters play with 4 invocation counters on it.\n<b>Forced Response:</b> After the last invocation counter is removed from Fireball, discard it → deal 4 damage to your identity.",
+		"text": "Surge.\nEnters play with 4 invocation counters on it.\n<b>Forced Response</b>: After the last invocation counter is removed from Fireball, discard it → deal 4 damage to your identity.",
 		"traits": "Spell.",
 		"type_code": "environment"
 	},
@@ -320,7 +320,7 @@
 		"quantity": 2,
 		"set_code": "ebony_maw",
 		"set_position": 8,
-		"text": "Surge.\nEnters play with 2 invocation counters on it.\n<b>Forced Response:</b> After the last invocation counter is removed from Manipulation, discard it → discard 1 card at random from your hand. You are confused.",
+		"text": "Surge.\nEnters play with 2 invocation counters on it.\n<b>Forced Response</b>: After the last invocation counter is removed from Manipulation, discard it → discard 1 card at random from your hand. You are confused.",
 		"traits": "Spell.",
 		"type_code": "environment"
 	},
@@ -335,7 +335,7 @@
 		"quantity": 2,
 		"set_code": "ebony_maw",
 		"set_position": 10,
-		"text": "Surge.\nEnters play with 3 invocation counters on it.\n<b>Forced Response:</b> After the last invocation counter is removed from Pacification, discard it → exhaust each upgrade you control. You are stunned.",
+		"text": "Surge.\nEnters play with 3 invocation counters on it.\n<b>Forced Response</b>: After the last invocation counter is removed from Pacification, discard it → exhaust each upgrade you control. You are stunned.",
 		"traits": "Spell.",
 		"type_code": "environment"
 	},
@@ -350,7 +350,7 @@
 		"quantity": 2,
 		"set_code": "ebony_maw",
 		"set_position": 12,
-		"text": "Surge.\nEnters play with 3 invocation counters on it.\n<b>Forced Response:</b> After the last invocation counter is removed from Rubblestorm, discard it → deal 2 damage to each character you control.",
+		"text": "Surge.\nEnters play with 3 invocation counters on it.\n<b>Forced Response</b>: After the last invocation counter is removed from Rubblestorm, discard it → deal 2 damage to each character you control.",
 		"traits": "Spell.",
 		"type_code": "environment"
 	},
@@ -365,7 +365,7 @@
 		"quantity": 2,
 		"set_code": "ebony_maw",
 		"set_position": 14,
-		"text": "<b>When Revealed (Alter-Ego):</b> Place 1 threat on the main scheme for each [[Spell]] environment in your play area. If you place no threat this way, this card gains surge.\n<b>When Revealed (Hero):</b> Deal 1 damage to your hero for each [[Spell]] environment in your play area. If you take no damage this way, this card gains surge.",
+		"text": "<b>When Revealed (Alter-Ego)</b>: Place 1 threat on the main scheme for each [[Spell]] environment in your play area. If you place no threat this way, this card gains surge.\n<b>When Revealed (Hero)</b>: Deal 1 damage to your hero for each [[Spell]] environment in your play area. If you take no damage this way, this card gains surge.",
 		"type_code": "treachery"
 	},
 	{
@@ -379,7 +379,7 @@
 		"quantity": 3,
 		"set_code": "ebony_maw",
 		"set_position": 16,
-		"text": "<b>When Revealed:</b> Remove 1 invocation counter from each [[Spell]] environment in your play area. If you have no [[Spell]] environments in your play area, discard cards from the top of the encounter deck until a [[Spell]] environment is discarded. Put that card into play in your play area.",
+		"text": "<b>When Revealed</b>: Remove 1 invocation counter from each [[Spell]] environment in your play area. If you have no [[Spell]] environments in your play area, discard cards from the top of the encounter deck until a [[Spell]] environment is discarded. Put that card into play in your play area.",
 		"type_code": "treachery"
 	},
 	{
@@ -393,7 +393,7 @@
 		"quantity": 1,
 		"set_code": "ebony_maw",
 		"set_position": 19,
-		"text": "Attach to Ebony Maw.\nPrevent all damage to Ebony Maw.\n<b>Forced Response:</b> After Abjuration prevents 2 or more damage from a single attack, discard it.",
+		"text": "Attach to Ebony Maw.\nPrevent all damage to Ebony Maw.\n<b>Forced Response</b>: After Abjuration prevents 2 or more damage from a single attack, discard it.",
 		"type_code": "attachment"
 	},
 	{
@@ -408,7 +408,7 @@
 		"quantity": 1,
 		"set_code": "ebony_maw",
 		"set_position": 20,
-		"text": "Attach to a friendly character with the highest ATK and exhaust it.\nAttached character cannot ready.\n<b>Hero Action:</b> Spend [energy][physical] resources → discard this card.",
+		"text": "Attach to a friendly character with the highest ATK and exhaust it.\nAttached character cannot ready.\n<b>Hero Action</b>: Spend [energy][physical] resources → discard this card.",
 		"type_code": "attachment"
 	},
 	{
@@ -426,7 +426,7 @@
 		"scheme_crisis": 1,
 		"set_code": "ebony_maw",
 		"set_position": 21,
-		"text": "<b>When Revealed:</b> Each player must choose to either take 2 damage or place 2 threat here.",
+		"text": "<b>When Revealed</b>: Each player must choose to either take 2 damage or place 2 threat here.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -465,7 +465,7 @@
 		"scheme": 2,
 		"set_code": "black_order",
 		"set_position": 2,
-		"text": "Quickstrike.\n[star] <b>Forced Response:</b> After supergiant attacks and damages a character, that character is stunned.",
+		"text": "Quickstrike.\n[star] <b>Forced Response</b>: After supergiant attacks and damages a character, that character is stunned.",
 		"traits": "Black Order. Elite.",
 		"type_code": "minion"
 	},
@@ -496,7 +496,7 @@
 		"quantity": 1,
 		"set_code": "black_order",
 		"set_position": 4,
-		"text": "<b>When Revealed:</b> Each minion engaged with a player activates against that player. Each player who is not engaged with a minion searches the encounter deck and discard pile for a [[Black Order]] minion and puts it into play engaged with them. Shuffle the encounter deck.",
+		"text": "<b>When Revealed</b>: Each minion engaged with a player activates against that player. Each player who is not engaged with a minion searches the encounter deck and discard pile for a [[Black Order]] minion and puts it into play engaged with them. Shuffle the encounter deck.",
 		"type_code": "treachery"
 	},
 	{
@@ -513,7 +513,7 @@
 		"scheme": 1,
 		"set_code": "armies_of_titan",
 		"set_position": 1,
-		"text": "Guard.\n<b>When Defeated:</b> Give the villain a tough status card.\n<hr />\n[star] <b>Boost</b>: Give the villain a tough status card.",
+		"text": "Guard.\n<b>When Defeated</b>: Give the villain a tough status card.\n<hr />\n[star] <b>Boost</b>: Give the villain a tough status card.",
 		"traits": "Black Order.",
 		"type_code": "minion"
 	},
@@ -531,7 +531,7 @@
 		"scheme": 1,
 		"set_code": "armies_of_titan",
 		"set_position": 3,
-		"text": "<b>When Revealed:</b> Discard 1 card at random from your hand.\n<hr />\n[star] <b>Boost</b>: Discard 1 card at random from your hand.",
+		"text": "<b>When Revealed</b>: Discard 1 card at random from your hand.\n<hr />\n[star] <b>Boost</b>: Discard 1 card at random from your hand.",
 		"traits": "Black Order.",
 		"type_code": "minion"
 	},
@@ -548,7 +548,7 @@
 		"scheme_acceleration": 1,
 		"set_code": "armies_of_titan",
 		"set_position": 5,
-		"text": "<b>When Defeated:</b> Discard cards from the top of the encounter deck until a minion is discarded. Put that minion into play engaged with the player who defeated this scheme.",
+		"text": "<b>When Defeated</b>: Discard cards from the top of the encounter deck until a minion is discarded. Put that minion into play engaged with the player who defeated this scheme.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -567,8 +567,8 @@
 		"scheme": 1,
 		"set_code": "tower_defense",
 		"set_position": 1,
-		"stage": 1,
-		"text": "[star] <b>Forced Interrupt:</b> When Proxima Midnight attacks you, choose to either deal 1 damage to Avenger's Tower, or Proxima Midnight gets +2 ATK for this attack.\n<b>Proxima Midnight cannot be defeated while Corvus Glaive has any hit points remaining.</b>",
+		"stage": "I",
+		"text": "[star] <b>Forced Interrupt</b>: When Proxima Midnight attacks you, choose to either deal 1 damage to Avenger's Tower, or Proxima Midnight gets +2 ATK for this attack.\n<b>Proxima Midnight cannot be defeated while Corvus Glaive has any hit points remaining.</b>",
 		"traits": "Black Order.",
 		"type_code": "villain"
 	},
@@ -588,7 +588,7 @@
 		"scheme": 1,
 		"set_code": "tower_defense",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "II",
 		"text": "[star] <b>Forced Interrupt</b>: When Proxima Midnight attacks you, choose to either deal 1 damage to Avenger's Tower, or Proxima Midnight gets +2 ATK for this attack.\n<b> Proxima Midnight cannot be defeated while Corvus Glaive has any hit points remaining </b>",
 		"traits": "Black Order.",
 		"type_code": "villain"
@@ -609,7 +609,7 @@
 		"scheme": 2,
 		"set_code": "tower_defense",
 		"set_position": 3,
-		"stage": 3,
+		"stage": "III",
 		"text": "[star] <b>Forced Interrupt</b>: When Proxima Midnight attacks you, choose to either deal 1 damage to Avenger's Tower, or Proxima Midnight gets +2 ATK for this attack.\n<b> Proxima Midnight cannot be defeated while Corvus Glaive has any hit points remaining </b>",
 		"traits": "Black Order.",
 		"type_code": "villain"
@@ -630,7 +630,7 @@
 		"scheme": 2,
 		"set_code": "tower_defense",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "I",
 		"text": "[star] <b>Forced Interrupt</b>: After Corvus Glaive makes an undefended attack, discard the top card of the encounter deck → deal 1 damage to Avenger's Tower for each boost icon ([boost]) on that card.\n<b>Corvus Glaive cannot be defeated while Proxima Midnight has any hit points remaining.</b>",
 		"traits": "Black Order.",
 		"type_code": "villain"
@@ -651,7 +651,7 @@
 		"scheme": 2,
 		"set_code": "tower_defense",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "II",
 		"text": "[star] <b>Forced Interrupt</b>: After Corvus Glaive makes an undefended attack, discard the top card of the encounter deck → deal 1 damage to Avenger's Tower for each boost icon [[boost]] on that card.\n<b> Corvus Glaive cannot be defeated while Proxima Midnight has any hit points remaining </b>",
 		"traits": "Black Order.",
 		"type_code": "villain"
@@ -672,7 +672,7 @@
 		"scheme": 3,
 		"set_code": "tower_defense",
 		"set_position": 6,
-		"stage": 3,
+		"stage": "III",
 		"text": "[star] <b>Forced Interrupt</b>: After Corvus Glaive makes an undefended attack, discard the top card of the encounter deck → deal 1 damage to Avenger's Tower for each boost icon [[boost]] on that card.\n<b> Corvus Glaive cannot be defeated while Proxima Midnight has any hit points remaining </b>",
 		"traits": "Black Order.",
 		"type_code": "villain"
@@ -688,8 +688,8 @@
 		"quantity": 1,
 		"set_code": "tower_defense",
 		"set_position": 7,
-		"stage": 1,
-		"text": "<b>Contents:</b> Proxima Midnight I and II <i>(stages (II) and (III) instead for expert mode)</i>. Corvus Glaive I and II <i>(stages (II) and (III) instead for expert mode)</i>. Tower Defense and Standard sets. One modular encounter set <i>(Armies of Titan)</i>.\n<b>Setup:</b> Reveal stage 2A and put it into play next to this stage so there are two main schemes and two villains in play.",
+		"stage": "1A",
+		"text": "<b>Contents</b>: Proxima Midnight I and II <i>(stages (II) and (III) instead for expert mode)</i>. Corvus Glaive I and II <i>(stages (II) and (III) instead for expert mode)</i>. Tower Defense and Standard sets. One modular encounter set <i>(Armies of Titan)</i>.\n<b>Setup</b>: Reveal stage 2A and put it into play next to this stage so there are two main schemes and two villains in play.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -705,8 +705,8 @@
 		"quantity": 1,
 		"set_code": "tower_defense",
 		"set_position": 7,
-		"stage": 1,
-		"text": "<b><i>Proxima Midnight's Scheme.</i></b>\n<b>Forced Interrupt:</b> When this stage would be completed, remove all the threat from this stage instead. Then, deal 6[per_hero] damage to Avengers Tower.",
+		"stage": "1B",
+		"text": "<b><i>Proxima Midnight's Scheme.</i></b>\n<b>Forced Interrupt</b>: When this stage would be completed, remove all the threat from this stage instead. Then, deal 6[per_hero] damage to Avengers Tower.",
 		"threat": 6,
 		"type_code": "main_scheme"
 	},
@@ -721,8 +721,8 @@
 		"quantity": 1,
 		"set_code": "tower_defense",
 		"set_position": 8,
-		"stage": 2,
-		"text": "<b>When Revealed:</b> Put the Avengers Tower environment into play, [[stronghold]] side faceup. Put the Focused Defense attachment into play attached to this stage. Each player searches the encounter deck for a copy of Black Order Besieger and puts it into play engaged with them. Shuffle the encounter deck.",
+		"stage": "2A",
+		"text": "<b>When Revealed</b>: Put the Avengers Tower environment into play, [[stronghold]] side faceup. Put the Focused Defense attachment into play attached to this stage. Each player searches the encounter deck for a copy of Black Order Besieger and puts it into play engaged with them. Shuffle the encounter deck.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -738,8 +738,8 @@
 		"quantity": 1,
 		"set_code": "tower_defense",
 		"set_position": 8,
-		"stage": 2,
-		"text": "<b><i>Corvus Glaive's Scheme.</i></b>\n<b>Forced Interrupt:</b> When this stage would be completed, remove all the threat from this stage instead. Then, deal each player 1 facedown encounter card.",
+		"stage": "2B",
+		"text": "<b><i>Corvus Glaive's Scheme.</i></b>\n<b>Forced Interrupt</b>: When this stage would be completed, remove all the threat from this stage instead. Then, deal each player 1 facedown encounter card.",
 		"threat": 6,
 		"type_code": "main_scheme"
 	},
@@ -754,7 +754,7 @@
 		"quantity": 1,
 		"set_code": "tower_defense",
 		"set_position": 9,
-		"text": "The unique rule does not apply to Avengers Tower.\n<b>Forced Response:</b> After damage is placed here, if there is at least 9[per_hero] damage here, remove all of it. Then flip Avengers Tower over.",
+		"text": "The unique rule does not apply to Avengers Tower.\n<b>Forced Response</b>: After damage is placed here, if there is at least 9[per_hero] damage here, remove all of it. Then flip Avengers Tower over.",
 		"traits": "Stronghold.",
 		"type_code": "environment"
 	},
@@ -769,7 +769,7 @@
 		"quantity": 1,
 		"set_code": "tower_defense",
 		"set_position": 9,
-		"text": "<b>When Revealed:</b> Discard each other Avengers Tower from play.\n<b>Forced Response:</b> After damage is placed here, if there is at least 9[per_hero] damage here, the players lose the game.",
+		"text": "<b>When Revealed</b>: Discard each other Avengers Tower from play.\n<b>Forced Response</b>: After damage is placed here, if there is at least 9[per_hero] damage here, the players lose the game.",
 		"traits": "Damaged.",
 		"type_code": "environment"
 	},
@@ -784,7 +784,7 @@
 		"quantity": 1,
 		"set_code": "tower_defense",
 		"set_position": 10,
-		"text": "Permanent.\nThe villain who matches the attached scheme is the active villain.\n<b>Forced Response:</b> After the player phase ends, attach this card to the other main scheme.",
+		"text": "Permanent.\nThe villain who matches the attached scheme is the active villain.\n<b>Forced Response</b>: After the player phase ends, attach this card to the other main scheme.",
 		"type_code": "attachment"
 	},
 	{
@@ -801,7 +801,7 @@
 		"scheme": 1,
 		"set_code": "tower_defense",
 		"set_position": 11,
-		"text": "<b>Forced Response:</b> After Black Order Besieger engages you, choose to either deal 1 damage to Avengers Tower or deal 2 damage to your identity.",
+		"text": "<b>Forced Response</b>: After Black Order Besieger engages you, choose to either deal 1 damage to Avengers Tower or deal 2 damage to your identity.",
 		"traits": "Black Order.",
 		"type_code": "minion"
 	},
@@ -819,7 +819,7 @@
 		"quantity": 1,
 		"set_code": "tower_defense",
 		"set_position": 15,
-		"text": "Attach to Proxima Midnight.\n[star] Proxima Midnight's attacks gain overkill and piercing.\n<b>Hero Action:</b> Take 1 damage and spend [energy] [mental] resources → discard this card.",
+		"text": "Attach to Proxima Midnight.\n[star] Proxima Midnight's attacks gain overkill and piercing.\n<b>Hero Action</b>: Take 1 damage and spend [energy] [mental] resources → discard this card.",
 		"traits": "Weapon.",
 		"type_code": "attachment"
 	},
@@ -867,7 +867,7 @@
 		"quantity": 2,
 		"set_code": "tower_defense",
 		"set_position": 19,
-		"text": "<b>When Revealed:</b> Proxima Midnight activates against you.\n<hr />\n[star] <b>Boost</b>: Add the other villain's SCH and ATK to this villain's SCH and ATK for this activation.",
+		"text": "<b>When Revealed</b>: Proxima Midnight activates against you.\n<hr />\n[star] <b>Boost</b>: Add the other villain's SCH and ATK to this villain's SCH and ATK for this activation.",
 		"type_code": "treachery"
 	},
 	{
@@ -881,7 +881,7 @@
 		"quantity": 2,
 		"set_code": "tower_defense",
 		"set_position": 21,
-		"text": "<b>When Revealed:</b> Corvus Glaive activates against you.\n<hr />\n[star] <b>Boost</b>: Add the other villain's SCH and ATK to this villain's SCH and ATK for this activation.",
+		"text": "<b>When Revealed</b>: Corvus Glaive activates against you.\n<hr />\n[star] <b>Boost</b>: Add the other villain's SCH and ATK to this villain's SCH and ATK for this activation.",
 		"type_code": "treachery"
 	},
 	{
@@ -895,7 +895,7 @@
 		"quantity": 1,
 		"set_code": "tower_defense",
 		"set_position": 23,
-		"text": "<b>When Revealed:</b> Heal 2 damage from each villain. Give each villain a tough status card.\n<hr />\n[star] <b>Boost</b>: Heal 2 damage from the active villain and give it a tough status card.",
+		"text": "<b>When Revealed</b>: Heal 2 damage from each villain. Give each villain a tough status card.\n<hr />\n[star] <b>Boost</b>: Heal 2 damage from the active villain and give it a tough status card.",
 		"type_code": "treachery"
 	},
 	{
@@ -926,7 +926,7 @@
 		"scheme_crisis": 1,
 		"set_code": "tower_defense",
 		"set_position": 26,
-		"text": "Hinder 1[per_hero].\n<b>When Defeated:</b> The player who defeated this scheme draws 1 card.",
+		"text": "Hinder 1[per_hero].\n<b>When Defeated</b>: The player who defeated this scheme draws 1 card.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -944,8 +944,8 @@
 		"scheme": 1,
 		"set_code": "thanos",
 		"set_position": 1,
-		"stage": 1,
-		"text": "Stalwart. <i>(This character cannot be stunned or confused.)</i>\n<b>Forced Response:</b> After the [[infinity stone]] deck runs out, give Thanos 1 facedown boost card.",
+		"stage": "I",
+		"text": "Stalwart. <i>(This character cannot be stunned or confused.)</i>\n<b>Forced Response</b>: After the [[infinity stone]] deck runs out, give Thanos 1 facedown boost card.",
 		"traits": "Black Order. Titan.",
 		"type_code": "villain"
 	},
@@ -964,8 +964,8 @@
 		"scheme": 2,
 		"set_code": "thanos",
 		"set_position": 2,
-		"stage": 2,
-		"text": "Stalwart. Toughness.\n<b>When Revealed:</b> Search the encounter deck and discard pile for Thanos's Helmet and reveal it. <i>(Shuffle.)</i>\n<b>Forced Response:</b> After the [[infinity stone]] deck runs out, give Thanos 1 facedown boost card.",
+		"stage": "II",
+		"text": "Stalwart. Toughness.\n<b>When Revealed</b>: Search the encounter deck and discard pile for Thanos's Helmet and reveal it. <i>(Shuffle.)</i>\n<b>Forced Response</b>: After the [[infinity stone]] deck runs out, give Thanos 1 facedown boost card.",
 		"traits": "Black Order. Titan.",
 		"type_code": "villain"
 	},
@@ -984,8 +984,8 @@
 		"scheme": 2,
 		"set_code": "thanos",
 		"set_position": 3,
-		"stage": 3,
-		"text": "Stalwart. Toughness.\n<b>When Revealed:</b> Search the encounter deck and discard pile for Thanos's Helmet and reveal it. <i>(Shuffle.)</i>\n<b>Forced Response:</b> After the [[infinity stone]] deck runs out, give Thanos 1 facedown boost card.",
+		"stage": "III",
+		"text": "Stalwart. Toughness.\n<b>When Revealed</b>: Search the encounter deck and discard pile for Thanos's Helmet and reveal it. <i>(Shuffle.)</i>\n<b>Forced Response</b>: After the [[infinity stone]] deck runs out, give Thanos 1 facedown boost card.",
 		"traits": "Black Order. Titan.",
 		"type_code": "villain"
 	},
@@ -1000,8 +1000,8 @@
 		"quantity": 1,
 		"set_code": "thanos",
 		"set_position": 4,
-		"stage": 1,
-		"text": "<b>Contents:</b> Thanos I and Thanos II <i>(Thanos II and Thanos III for expert mode)</i>. Thanos, Infinity Gaultlet and Standard sets. Two modular sets <i>(Black Order and Children of Thanos)</i>. See rules insert for The Infinity Gauntlet rules.",
+		"stage": "1A",
+		"text": "<b>Contents</b>: Thanos I and Thanos II <i>(Thanos II and Thanos III for expert mode)</i>. Thanos, Infinity Gaultlet and Standard sets. Two modular sets <i>(Black Order and Children of Thanos)</i>. See rules insert for The Infinity Gauntlet rules.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -1018,8 +1018,8 @@
 		"quantity": 1,
 		"set_code": "thanos",
 		"set_position": 4,
-		"stage": 1,
-		"text": "<b>When Revealed:</b> Put the top card of the [[infinity stone]] deck into play. Search the encounter deck for the Sanctuary side scheme and reveal it. <i>(Shuffle the encounter deck.)</i>",
+		"stage": "1B",
+		"text": "<b>When Revealed</b>: Put the top card of the [[infinity stone]] deck into play. Search the encounter deck for the Sanctuary side scheme and reveal it. <i>(Shuffle the encounter deck.)</i>",
 		"threat": 12,
 		"type_code": "main_scheme"
 	},
@@ -1034,7 +1034,7 @@
 		"quantity": 1,
 		"set_code": "thanos",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2A",
 		"text": "<b>If this stage is completed, the players lose the game.</b>",
 		"type_code": "main_scheme"
 	},
@@ -1051,8 +1051,8 @@
 		"quantity": 1,
 		"set_code": "thanos",
 		"set_position": 5,
-		"stage": 2,
-		"text": "<b>When Revealed:</b> Each player shuffles their discard pile into their deck. Each player removes the top half of their deck (rounded down) from the game.",
+		"stage": "2B",
+		"text": "<b>When Revealed</b>: Each player shuffles their discard pile into their deck. Each player removes the top half of their deck (rounded down) from the game.",
 		"threat": 12,
 		"type_code": "main_scheme"
 	},
@@ -1070,7 +1070,7 @@
 		"quantity": 1,
 		"set_code": "thanos",
 		"set_position": 6,
-		"text": "Hinder 1[per_hero]. Victory 1.\nThanos cannot take damage from player cards.\n<b>When Defeated:</b> Each player may spend up to 3 [physical] resources from their hand. Deal 2 damage to Thanos for each [physical] resource spent this way. This damage ignores the tough status card.",
+		"text": "Hinder 1[per_hero]. Victory 1.\nThanos cannot take damage from player cards.\n<b>When Defeated</b>: Each player may spend up to 3 [physical] resources from their hand. Deal 2 damage to Thanos for each [physical] resource spent this way. This damage ignores the tough status card.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1085,7 +1085,7 @@
 		"quantity": 1,
 		"set_code": "thanos",
 		"set_position": 7,
-		"text": "Attach to Thanos.\n<b>Forced Interrupt</b>: When Thanos would take any amount of damage, reduce that amount by 1.\n<b>Hero Response:<b> After a hero makes a basic attack against Thanos, spend [energy] [physical] resources → discard this card.",
+		"text": "Attach to Thanos.\n<b>Forced Interrupt</b>: When Thanos would take any amount of damage, reduce that amount by 1.\n<b>Hero Response</b>: After a hero makes a basic attack against Thanos, spend [energy] [physical] resources → discard this card.",
 		"traits": "Armor.",
 		"type_code": "attachment"
 	},
@@ -1120,7 +1120,7 @@
 		"scheme_star": true,
 		"set_code": "thanos",
 		"set_position": 9,
-		"text": "Attach to Thanos. [star] <b>Forced Interrupt:</b> When Thanos activates, put the top card of the [[infinity stone]] deck into play. At the end of this activation, discard Master of the Stones.",
+		"text": "Attach to Thanos. [star] <b>Forced Interrupt</b>: When Thanos activates, put the top card of the [[infinity stone]] deck into play. At the end of this activation, discard Master of the Stones.",
 		"type_code": "attachment"
 	},
 	{
@@ -1162,7 +1162,7 @@
 		"quantity": 2,
 		"set_code": "thanos",
 		"set_position": 15,
-		"text": "<b>When Revealed:</b>Give Thanos 1 facedown boost card.\n<hr />\n[star] <b>Boost</b>: Discard the top card of the [[infinity stone]] deck. Apply its boost icons ([boost]) for this activation as if it were a boost card.",
+		"text": "<b>When Revealed</b>:Give Thanos 1 facedown boost card.\n<hr />\n[star] <b>Boost</b>: Discard the top card of the [[infinity stone]] deck. Apply its boost icons ([boost]) for this activation as if it were a boost card.",
 		"type_code": "treachery"
 	},
 	{
@@ -1176,7 +1176,7 @@
 		"quantity": 2,
 		"set_code": "thanos",
 		"set_position": 17,
-		"text": "<b>When Revealed:</b> Put the top card of the infinity stone deck into play.\n<hr />\n[star] <b>Boost</b>: If damage from this attack defeats an ally, put the top card of the infinity stone deck into play",
+		"text": "<b>When Revealed</b>: Put the top card of the infinity stone deck into play.\n<hr />\n[star] <b>Boost</b>: If damage from this attack defeats an ally, put the top card of the infinity stone deck into play",
 		"type_code": "treachery"
 	},
 	{
@@ -1192,7 +1192,7 @@
 		"scheme_amplify": 1,
 		"set_code": "thanos",
 		"set_position": 19,
-		"text": "<b>When Revealed:</b> Put the top card of the [[infinity stone]] deck into play.",
+		"text": "<b>When Revealed</b>: Put the top card of the [[infinity stone]] deck into play.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1267,7 +1267,7 @@
 		"scheme_crisis": 1,
 		"set_code": "children_of_thanos",
 		"set_position": 4,
-		"text": "<b>When Defeated:</b> Deal the player who defeated this scheme a facedown encounter card",
+		"text": "<b>When Defeated</b>: Deal the player who defeated this scheme a facedown encounter card",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1399,7 +1399,7 @@
 		"scheme_star": true,
 		"set_code": "hela",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "A1",
 		"text": "[star] Hela gets +1 SCH, +1 ATK and +2[per_hero] hit points for each side scheme in victory display.\n<b> When Hela is defeated, if Odin is not attached to the main scheme, you win the game </b>",
 		"traits": "Asgard. Mystic.",
 		"type_code": "villain"
@@ -1419,7 +1419,7 @@
 		"scheme": 0,
 		"set_code": "hela",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "A2",
 		"text": "Hela cannot be defeated.\n<b>Forced Response</b>: After a side scheme is defeated, flip Hela to her [[mystic]] side.",
 		"traits": "Asgard. Wounded.",
 		"type_code": "villain"
@@ -1442,7 +1442,7 @@
 		"scheme_star": true,
 		"set_code": "hela",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "B1",
 		"text": "[star] Hela gets +1 SCH, +1 ATK and +3[per_hero] hit points for each side scheme in victory display.\n<b> When Hela is defeated, if Odin is not attached to the main scheme, you win the game </b>",
 		"traits": "Asgard. Mystic.",
 		"type_code": "villain"
@@ -1462,7 +1462,7 @@
 		"scheme": 1,
 		"set_code": "hela",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "B2",
 		"text": "Hela cannot be defeated.\n<b>Forced Response</b>: After a side scheme is defeated, flip Hela to her [[mystic]] side.",
 		"traits": "Asgard. Wounded.",
 		"type_code": "villain"
@@ -1478,7 +1478,7 @@
 		"quantity": 1,
 		"set_code": "hela",
 		"set_position": 3,
-		"stage": 1,
+		"stage": "1A",
 		"text": "<b> Contents: </b> Villain deck Hela A (Hela B instead for expert mode). Hela and standard sets. Two modular encounter sets (Legions of Hel and Frost Giants).\n<b> Setup: </b> Attach Odin to the main scheme, [[captive]] side faceup. Reveal Gnipahellir and Garm. Set Gjallerbru, Skurge, Hall of Nastrond, and Nidhogg aside, out of play. Shuffle the encounter deck.",
 		"type_code": "main_scheme"
 	},
@@ -1495,7 +1495,7 @@
 		"quantity": 1,
 		"set_code": "hela",
 		"set_position": 3,
-		"stage": 1,
+		"stage": "1B",
 		"text": "<b> Forced Interrupt: </b> When Hela would be defeated, if Odin is attached to this scheme, discard each attachment from Hela and flip her to her [[wounded]] side instead.\n<b> If this scheme is completed, the players lose the game. </b>",
 		"threat": 18,
 		"type_code": "main_scheme"
@@ -1768,7 +1768,7 @@
 		"scheme": 1,
 		"set_code": "legions_of_hel",
 		"set_position": 1,
-		"text": "Guard.\n<b> When Revealed:</b> Choose to either take 1 damage or place 1 threat on the main scheme.",
+		"text": "Guard.\n<b> When Revealed</b>: Choose to either take 1 damage or place 1 threat on the main scheme.",
 		"traits": "Undead.",
 		"type_code": "minion"
 	},
@@ -1834,7 +1834,7 @@
 		"scheme": 2,
 		"set_code": "frost_giants",
 		"set_position": 1,
-		"text": "Toughness.\n[star] <b>Forced Response:</b> After Laufey attacks and damages a character, stun that character.",
+		"text": "Toughness.\n[star] <b>Forced Response</b>: After Laufey attacks and damages a character, stun that character.",
 		"traits": "Elite. Giant.",
 		"type_code": "minion"
 	},
@@ -1884,7 +1884,7 @@
 		"quantity": 1,
 		"set_code": "frost_giants",
 		"set_position": 6,
-		"text": "Heroes and allies cannot be readied by player card effects.\n<b> When Revealed:</b> Exhaust each ally in play.",
+		"text": "Heroes and allies cannot be readied by player card effects.\n<b> When Revealed</b>: Exhaust each ally in play.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1902,7 +1902,7 @@
 		"scheme": 2,
 		"set_code": "loki",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "Victory 1.\nLoki cannot take damage while a side scheme is in play.\n<b> When Defeated: </b> Discard cards from the top of the encounter deck until a side scheme is discarded. Reveal that side scheme.",
 		"traits": "Asgard. Mystic.",
 		"type_code": "villain"
@@ -1922,7 +1922,7 @@
 		"scheme": 2,
 		"set_code": "loki",
 		"set_position": 2,
-		"stage": 1,
+		"stage": "I",
 		"text": "Retaliate 1. Victory 1.\n<b> When Defeated: </b> Discard cards from the top of the encounter deck until a side scheme is discarded. Reveal that side scheme.",
 		"traits": "Asgard. Mystic.",
 		"type_code": "villain"
@@ -1942,7 +1942,7 @@
 		"scheme": 1,
 		"set_code": "loki",
 		"set_position": 3,
-		"stage": 1,
+		"stage": "I",
 		"text": "Stalwart. Victory 1.\n<b> When Defeated: </b> Discard cards from the top of the encounter deck until a side scheme is discarded. Reveal that side scheme.",
 		"traits": "Asgard. Mystic.",
 		"type_code": "villain"
@@ -1962,7 +1962,7 @@
 		"scheme": 3,
 		"set_code": "loki",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "I",
 		"text": "Stalwart. Victory 1.\n<b> When Defeated: </b> Discard cards from the top of the encounter deck until a side scheme is discarded. Reveal that side scheme.",
 		"traits": "Asgard. Mystic.",
 		"type_code": "villain"
@@ -1983,7 +1983,7 @@
 		"scheme": 1,
 		"set_code": "loki",
 		"set_position": 5,
-		"stage": 1,
+		"stage": "I",
 		"text": "Victory 1.\n[star] Loki's attacks gain piercing.\n<b> When Defeated: </b> Discard cards from the top of the encounter deck until a side scheme is discarded. Reveal that side scheme.",
 		"traits": "Asgard. Mystic.",
 		"type_code": "villain"
@@ -1999,8 +1999,8 @@
 		"quantity": 1,
 		"set_code": "loki",
 		"set_position": 6,
-		"stage": 1,
-		"text": "<b>Contents</b>: Loki, Infinity Gauntlet, and Standard encounter sets. Two modular encounter sets. <i>(Enchantress and Frost Giants).</i>\n<b>Setup:</b> Set each copy of the Loki villain aside, out of play. Put the War in Asgard side scheme into play. Shuffle the encounter deck. Reveal 1 set-aside Loki villain at random. Reveal the top card of the [[infinity stone]] deck.",
+		"stage": "1A",
+		"text": "<b>Contents</b>: Loki, Infinity Gauntlet, and Standard encounter sets. Two modular encounter sets. <i>(Enchantress and Frost Giants).</i>\n<b>Setup</b>: Set each copy of the Loki villain aside, out of play. Put the War in Asgard side scheme into play. Shuffle the encounter deck. Reveal 1 set-aside Loki villain at random. Reveal the top card of the [[infinity stone]] deck.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -2016,7 +2016,7 @@
 		"quantity": 1,
 		"set_code": "loki",
 		"set_position": 6,
-		"stage": 1,
+		"stage": "1B",
 		"text": "<b>Forced Interrupt</b>: When Loki is defeated, advance to a random set-aside Loki villain.\n<b> If the number of Lokis in the victory display is equal to the victory condition, the players win the game. (See rule insert.) If this stage is completed, the players lose the game.</b>",
 		"threat": 12,
 		"type_code": "main_scheme"

--- a/pack/mut_gen_encounter.json
+++ b/pack/mut_gen_encounter.json
@@ -183,7 +183,7 @@
 		"scheme_star": true,
 		"set_code": "sabretooth",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "[star] <b>Forced Response</b>: After Sabretooth activates against you, discard the top card of the encounter deck. Heal damage from Sabretooth equal to the number of boost icons ([boost]) discarded this way.",
 		"traits": "Brotherhood of Mutants.",
 		"type_code": "villain"
@@ -205,7 +205,7 @@
 		"scheme_star": true,
 		"set_code": "sabretooth",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "II",
 		"text": "Toughness.\n[star] <b>Forced Response</b>: After Sabretooth activates against you, discard the top card of the encounter deck. Heal damage from Sabretooth equal to the number of boost icons ([boost]) discarded this way.",
 		"traits": "Brotherhood of Mutants.",
 		"type_code": "villain"
@@ -227,7 +227,7 @@
 		"scheme_star": true,
 		"set_code": "sabretooth",
 		"set_position": 3,
-		"stage": 3,
+		"stage": "III",
 		"text": "Retaliate 1. Toughness.\n[star] <b>Forced Response</b>: After Sabretooth activates against you, discard the top card of the encounter deck. Heal damage from Sabretooth equal to the number of boost icons ([boost]) discarded this way.",
 		"traits": "Brotherhood of Mutants.",
 		"type_code": "villain"
@@ -243,8 +243,8 @@
 		"quantity": 1,
 		"set_code": "sabretooth",
 		"set_position": 4,
-		"stage": 1,
-		"text": "<b>Contents:</b> Sabretooth (I) and Sabretooth (II). <i>(Sabretooth (II) and Sabretooth (III) for expert mode.)</i> Sabretooth and Standard sets. Two modular sets (<i>Brotherhood</i> and <i>Mystique</i>).\n<b>Setup:</b> Put the Find the Senator side scheme into play. Attach the Robert Kelly to it. While attached to Find the Senator, Robert Kelly is in play but under no player's control.",
+		"stage": "1A",
+		"text": "<b>Contents</b>: Sabretooth (I) and Sabretooth (II). <i>(Sabretooth (II) and Sabretooth (III) for expert mode.)</i> Sabretooth and Standard sets. Two modular sets (<i>Brotherhood</i> and <i>Mystique</i>).\n<b>Setup</b>: Put the Find the Senator side scheme into play. Attach the Robert Kelly to it. While attached to Find the Senator, Robert Kelly is in play but under no player's control.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -261,7 +261,7 @@
 		"quantity": 1,
 		"set_code": "sabretooth",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1B",
 		"text": "[star] <b>Forced Response</b>: After resolving step 1 of the villain phase, deal 2 damage to Robert Kelly (3 damage instead if there is at least 6[per_hero] threat here).\nWhile Robert Kelly is attached to Find the Senator, treat his text box as if it were blank.\n<b>If Robert Kelly leaves play, the players lose the game.</b>",
 		"type_code": "main_scheme"
 	},
@@ -277,7 +277,7 @@
 		"quantity": 1,
 		"set_code": "sabretooth",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2A",
 		"text": "<b>When Revealed</b>: Deal each player a facedown encounter card.",
 		"type_code": "main_scheme"
 	},
@@ -295,7 +295,7 @@
 		"quantity": 1,
 		"set_code": "sabretooth",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2B",
 		"text": "<b>When Completed</b>: Defeat Robert Kelly.\n<b>If Robert Kelly leaves play, the players lose the game.</b>",
 		"threat": 9,
 		"type_code": "main_scheme"
@@ -659,7 +659,7 @@
 		"scheme": 2,
 		"set_code": "project_wideawake",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "Toughness.\n<b>When Revealed</b>: The first player searches the encounter deck and discard pile for a copy of the Abduction Protocols side scheme and reveals it. <i>(Shuffle.)</i>",
 		"traits": "Sentinel.",
 		"type_code": "villain"
@@ -678,7 +678,7 @@
 		"scheme": 2,
 		"set_code": "project_wideawake",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "II",
 		"text": "Steady. Toughness.\n<b>When Revealed</b>: The first player searches the encounter deck and discard pile for a copy of the Abduction Protocols side scheme and reveals it. <i>(Shuffle.)</i> Deal each other player a facedown encounter card.",
 		"traits": "Sentinel.",
 		"type_code": "villain"
@@ -697,7 +697,7 @@
 		"scheme": 3,
 		"set_code": "project_wideawake",
 		"set_position": 3,
-		"stage": 3,
+		"stage": "III",
 		"text": "Stalwart. Toughness.\n<b>When Revealed</b>: The first player searches the encounter deck and discard pile for a copy of the Abduction Protocols side scheme and reveals it. <i>(Shuffle.)</i> Deal each other player a facedown encounter card.",
 		"traits": "Sentinel.",
 		"type_code": "villain"
@@ -713,8 +713,8 @@
 		"quantity": 1,
 		"set_code": "project_wideawake",
 		"set_position": 4,
-		"stage": 1,
-		"text": "<b>Contents:</b> Sentinel (I) and Sentinel (II). <i>(Sentinel (II) and Sentinel (III) for expert mode.)</i> Project Wideawake, Zero Tolerance, and Standard sets. One modular set (<i>Sentinels</i>).\n<b>Setup:</b> Set each [[Captive]] ally aside. Reveal the Operation Zero Tolerance and Mutants at the Mall side schemes.",
+		"stage": "1A",
+		"text": "<b>Contents</b>: Sentinel (I) and Sentinel (II). <i>(Sentinel (II) and Sentinel (III) for expert mode.)</i> Project Wideawake, Zero Tolerance, and Standard sets. One modular set (<i>Sentinels</i>).\n<b>Setup</b>: Set each [[Captive]] ally aside. Reveal the Operation Zero Tolerance and Mutants at the Mall side schemes.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -730,7 +730,7 @@
 		"quantity": 1,
 		"set_code": "project_wideawake",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1B",
 		"text": "Operation Zero Tolerance gains permanent.\n<b>Forced Response</b>: After threat is placed here, if there is at least 5[per_hero] threat here, the first player places the top card of their deck facedown under Operation Zero Tolerance. Then, remove 5[per_hero] threat from this scheme.",
 		"type_code": "main_scheme"
 	},
@@ -1152,7 +1152,7 @@
 		"scheme_star": true,
 		"set_code": "master_mold",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "Stalwart. Toughness.\n[star] <b>Forced Interrupt</b>: When Master Mold schemes against you, discard cards from the encounter deck until a [[Sentinel]] minion is discarded. Put that minion into play engaged with you. Do not give Master Mold a boost card for this activation.",
 		"traits": "Sentinel.",
 		"type_code": "villain"
@@ -1173,7 +1173,7 @@
 		"scheme_star": true,
 		"set_code": "master_mold",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "II",
 		"text": "Stalwart. Toughness.\n[star] <b>Forced Interrupt</b>: When Master Mold schemes against you, discard cards from the encounter deck until a [[Sentinel]] minion is discarded. Put that minion into play engaged with you. Do not give Master Mold a boost card for this activation.",
 		"traits": "Sentinel.",
 		"type_code": "villain"
@@ -1194,7 +1194,7 @@
 		"scheme_star": true,
 		"set_code": "master_mold",
 		"set_position": 3,
-		"stage": 3,
+		"stage": "III",
 		"text": "Stalwart. Toughness.\n[star] <b>Forced Interrupt</b>: When Master Mold schemes against you, discard cards from the encounter deck until a [[Sentinel]] minion is discarded. Put that minion into play engaged with you. Do not give Master Mold a boost card for this activation.",
 		"traits": "Sentinel.",
 		"type_code": "villain"
@@ -1210,8 +1210,8 @@
 		"quantity": 1,
 		"set_code": "master_mold",
 		"set_position": 4,
-		"stage": 1,
-		"text": "<b>Contents:</b> Master Mold (I) and Master Mold (II). <i>(Master Mold (II) and Master Mold (III) for expert mode.)</i> Master Mold, Sentinels, and Standard sets. One modular set (<i>Zero Tolerance</i>).\n<b>Setup:</b> Put the Magneto Ally (172B) into play under the first player's control.",
+		"stage": "1A",
+		"text": "<b>Contents</b>: Master Mold (I) and Master Mold (II). <i>(Master Mold (II) and Master Mold (III) for expert mode.)</i> Master Mold, Sentinels, and Standard sets. One modular set (<i>Zero Tolerance</i>).\n<b>Setup</b>: Put the Magneto Ally (172B) into play under the first player's control.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -1227,7 +1227,7 @@
 		"quantity": 1,
 		"set_code": "master_mold",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1B",
 		"text": "Each [[Sentinel]] minion gains guard.\n<b>When Revealed</b>: Each player discards cards from the encounter deck until they discard a [[Sentinel]] minion, then puts it into play engaged with them.",
 		"threat": 6,
 		"type_code": "main_scheme"
@@ -1243,7 +1243,7 @@
 		"quantity": 1,
 		"set_code": "master_mold",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2A",
 		"text": "<b>When Revealed</b>: Shuffle the encounter discard pile into the encounter deck. Each player discards cards from the encounter deck until they discard a [[Sentinel]] minion, then puts it into play engaged with them.",
 		"type_code": "main_scheme"
 	},
@@ -1261,7 +1261,7 @@
 		"quantity": 1,
 		"set_code": "master_mold",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2B",
 		"text": "Each [[Sentinel]] minion gains guard.\n<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 8,
 		"type_code": "main_scheme"
@@ -1391,7 +1391,7 @@
 		"health": 15,
 		"health_per_hero": true,
 		"is_unique": true,
-		"name": "Avalanche A",
+		"name": "Avalanche",
 		"octgn_id": "47d34c5d-5319-45a9-a2d6-1fb975032121",
 		"pack_code": "mut_gen",
 		"position": 121,
@@ -1399,6 +1399,7 @@
 		"scheme": 2,
 		"set_code": "mansion_attack",
 		"set_position": 1,
+		"stage": "A",
 		"text": "Toughness. Victory 2.\n[star] <b>Forced Response</b>: After Avalanche attacks you, exhaust an ally you control.",
 		"traits": "Brotherhood of Mutants.",
 		"type_code": "villain"
@@ -1413,7 +1414,7 @@
 		"health_per_hero": true,
 		"hidden": true,
 		"is_unique": true,
-		"name": "Avalanche B",
+		"name": "Avalanche",
 		"octgn_id": "47d34c5d-5319-45a9-a2d6-1fb975032121",
 		"pack_code": "mut_gen",
 		"position": 121,
@@ -1421,6 +1422,7 @@
 		"scheme": 2,
 		"set_code": "mansion_attack",
 		"set_position": 1,
+		"stage": "B",
 		"text": "Toughness. Victory 2.\n[star] <b>Forced Response</b>: After Avalanche attacks you, exhaust an ally you control.",
 		"traits": "Brotherhood of Mutants.",
 		"type_code": "villain"
@@ -1435,7 +1437,7 @@
 		"health": 16,
 		"health_per_hero": true,
 		"is_unique": true,
-		"name": "Blob A",
+		"name": "Blob",
 		"octgn_id": "47d34c5d-5319-45a9-a2d6-1fb975032122",
 		"pack_code": "mut_gen",
 		"position": 122,
@@ -1443,6 +1445,7 @@
 		"scheme": 1,
 		"set_code": "mansion_attack",
 		"set_position": 2,
+		"stage": "A",
 		"text": "Toughness. Victory 2.\n[star] <b>Forced Response</b>: After Blob attacks and damages a character, stun that character.",
 		"traits": "Brotherhood of Mutants.",
 		"type_code": "villain"
@@ -1457,7 +1460,7 @@
 		"health_per_hero": true,
 		"hidden": true,
 		"is_unique": true,
-		"name": "Blob B",
+		"name": "Blob",
 		"octgn_id": "47d34c5d-5319-45a9-a2d6-1fb975032122",
 		"pack_code": "mut_gen",
 		"position": 122,
@@ -1465,6 +1468,7 @@
 		"scheme": 2,
 		"set_code": "mansion_attack",
 		"set_position": 2,
+		"stage": "B",
 		"text": "Toughness. Victory 2.\n[star] <b>Forced Response</b>: After Blob attacks and damages a character, stun that character.",
 		"traits": "Brotherhood of Mutants.",
 		"type_code": "villain"
@@ -1478,7 +1482,7 @@
 		"health": 14,
 		"health_per_hero": true,
 		"is_unique": true,
-		"name": "Pyro A",
+		"name": "Pyro",
 		"octgn_id": "47d34c5d-5319-45a9-a2d6-1fb975032123",
 		"pack_code": "mut_gen",
 		"position": 123,
@@ -1486,6 +1490,7 @@
 		"scheme": 2,
 		"set_code": "mansion_attack",
 		"set_position": 3,
+		"stage": "A",
 		"text": "Toughness. Victory 2.\n[star] <b>Forced Response</b>: After Pyro attacks you, discard the top 2 cards of your deck. Take 1 indirect damage for each printed resource icon discarded this way.",
 		"traits": "Brotherhood of Mutants.",
 		"type_code": "villain"
@@ -1499,7 +1504,7 @@
 		"health_per_hero": true,
 		"hidden": true,
 		"is_unique": true,
-		"name": "Pyro B",
+		"name": "Pyro",
 		"octgn_id": "47d34c5d-5319-45a9-a2d6-1fb975032123",
 		"pack_code": "mut_gen",
 		"position": 123,
@@ -1507,6 +1512,7 @@
 		"scheme": 2,
 		"set_code": "mansion_attack",
 		"set_position": 3,
+		"stage": "B",
 		"text": "Toughness. Victory 2.\n[star] <b>Forced Response</b>: After Pyro attacks you, discard the top 2 cards of your deck. Take 1 indirect damage for each printed resource icon discarded this way.",
 		"traits": "Brotherhood of Mutants.",
 		"type_code": "villain"
@@ -1521,7 +1527,7 @@
 		"health": 13,
 		"health_per_hero": true,
 		"is_unique": true,
-		"name": "Toad A",
+		"name": "Toad",
 		"octgn_id": "47d34c5d-5319-45a9-a2d6-1fb975032124",
 		"pack_code": "mut_gen",
 		"position": 124,
@@ -1529,6 +1535,7 @@
 		"scheme": 2,
 		"set_code": "mansion_attack",
 		"set_position": 4,
+		"stage": "A",
 		"text": "Toughness. Victory 2.\n[star] <b>Forced Response</b>: After Toad attacks and damages a character you control, discard 1 random card from your hand.",
 		"traits": "Brotherhood of Mutants.",
 		"type_code": "villain"
@@ -1543,7 +1550,7 @@
 		"health_per_hero": true,
 		"hidden": true,
 		"is_unique": true,
-		"name": "Toad B",
+		"name": "Toad",
 		"octgn_id": "47d34c5d-5319-45a9-a2d6-1fb975032124",
 		"pack_code": "mut_gen",
 		"position": 124,
@@ -1551,6 +1558,7 @@
 		"scheme": 3,
 		"set_code": "mansion_attack",
 		"set_position": 4,
+		"stage": "B",
 		"text": "Toughness. Victory 2.\n[star] <b>Forced Response</b>: After Toad attacks and damages a character you control, discard 1 random card from your hand.",
 		"traits": "Brotherhood of Mutants.",
 		"type_code": "villain"
@@ -1566,8 +1574,8 @@
 		"quantity": 1,
 		"set_code": "mansion_attack",
 		"set_position": 5,
-		"stage": 1,
-		"text": "<b>Contents:</b> Avalanche (A), Blob (A), Pyro (A), and Toad (A). <i>(Use their (B) sides for expert mode.)</i> Mansion Attack, Brotherhood, and Standard sets. One modular set (<i>Mystique</i>).\n<b>Setup:</b> Put the Save the School environment into play. Shuffle all copies of main scheme 2A and stack them under this scheme. Shuffle the villains together <i>(without looking)</i> to create the villain deck. The top card of this deck is in play.",
+		"stage": "1A",
+		"text": "<b>Contents</b>: Avalanche (A), Blob (A), Pyro (A), and Toad (A). <i>(Use their (B) sides for expert mode.)</i> Mansion Attack, Brotherhood, and Standard sets. One modular set (<i>Mystique</i>).\n<b>Setup</b>: Put the Save the School environment into play. Shuffle all copies of main scheme 2A and stack them under this scheme. Shuffle the villains together <i>(without looking)</i> to create the villain deck. The top card of this deck is in play.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -1583,7 +1591,7 @@
 		"quantity": 1,
 		"set_code": "mansion_attack",
 		"set_position": 5,
-		"stage": 1,
+		"stage": "1B",
 		"text": "<b>When Revealed</b>: Deal each player a facedown encounter card. Advance to the next card in the main scheme deck. Add this card to the victory display.",
 		"threat": 0,
 		"type_code": "main_scheme"
@@ -1600,7 +1608,7 @@
 		"quantity": 1,
 		"set_code": "mansion_attack",
 		"set_position": 6,
-		"stage": 2,
+		"stage": "2A",
 		"text": "<b>When Revealed</b>: Flip this card.",
 		"type_code": "main_scheme"
 	},
@@ -1617,7 +1625,7 @@
 		"quantity": 1,
 		"set_code": "mansion_attack",
 		"set_position": 6,
-		"stage": 2,
+		"stage": "2B",
 		"text": "Each character gains steady.\n<b>When Completed</b>: Add this scheme to the victory display. Advance to the next card in the main scheme deck.\n <b>If there are 3 main schemes in the victory display, the players lose the game.</b>",
 		"threat": 7,
 		"type_code": "main_scheme"
@@ -1634,7 +1642,7 @@
 		"quantity": 1,
 		"set_code": "mansion_attack",
 		"set_position": 7,
-		"stage": 2,
+		"stage": "2A",
 		"text": "<b>When Revealed</b>: Flip this card.",
 		"type_code": "main_scheme"
 	},
@@ -1651,7 +1659,7 @@
 		"quantity": 1,
 		"set_code": "mansion_attack",
 		"set_position": 7,
-		"stage": 2,
+		"stage": "2B",
 		"text": "Each character gains retaliate 1.\n<b>When Completed</b>: Add this scheme to the victory display. Advance to the next card in the main scheme deck.\n <b>If there are 3 main schemes in the victory display, the players lose the game.</b>",
 		"threat": 7,
 		"type_code": "main_scheme"
@@ -1668,7 +1676,7 @@
 		"quantity": 1,
 		"set_code": "mansion_attack",
 		"set_position": 8,
-		"stage": 2,
+		"stage": "2A",
 		"text": "<b>When Revealed</b>: Flip this card.",
 		"type_code": "main_scheme"
 	},
@@ -1685,7 +1693,7 @@
 		"quantity": 1,
 		"set_code": "mansion_attack",
 		"set_position": 8,
-		"stage": 2,
+		"stage": "2B",
 		"text": "Each ally and minion gains toughness.\n<b>When Completed</b>: Add this scheme to the victory display. Advance to the next card in the main scheme deck.\n <b>If there are 3 main schemes in the victory display, the players lose the game.</b>",
 		"threat": 7,
 		"type_code": "main_scheme"
@@ -1702,7 +1710,7 @@
 		"quantity": 1,
 		"set_code": "mansion_attack",
 		"set_position": 9,
-		"stage": 2,
+		"stage": "2A",
 		"text": "<b>When Revealed</b>: Flip this card.",
 		"type_code": "main_scheme"
 	},
@@ -1719,7 +1727,7 @@
 		"quantity": 1,
 		"set_code": "mansion_attack",
 		"set_position": 9,
-		"stage": 2,
+		"stage": "2B",
 		"text": "Each character gains +1 ATK.\n<b>When Completed</b>: Add this scheme to the victory display. Advance to the next card in the main scheme deck.\n <b>If there are 3 main schemes in the victory display, the players lose the game.</b>",
 		"threat": 7,
 		"type_code": "main_scheme"
@@ -1861,7 +1869,7 @@
 		"scheme": 2,
 		"set_code": "magneto_villain",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "Steady. Toughness.\n[star] <b>Forced Response</b>: After Magneto attacks you, place 1 magnet counter on the main scheme.",
 		"traits": "Brotherhood of Mutants.",
 		"type_code": "villain"
@@ -1882,7 +1890,7 @@
 		"scheme": 2,
 		"set_code": "magneto_villain",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "II",
 		"text": "Steady. Toughness.\n<b>When Revealed</b>: Deal each player a facedown encounter card.\n[star] <b>Forced Response</b>: After Magneto attacks you, place 1 magnet counter on the main scheme.",
 		"traits": "Brotherhood of Mutants.",
 		"type_code": "villain"
@@ -1903,7 +1911,7 @@
 		"scheme": 3,
 		"set_code": "magneto_villain",
 		"set_position": 3,
-		"stage": 3,
+		"stage": "III",
 		"text": "Steady. Toughness.\n<b>When Revealed</b>: Deal each player a facedown encounter card.\n[star] <b>Forced Response</b>: After Magneto attacks you, place 1 magnet counter on the main scheme.",
 		"traits": "Brotherhood of Mutants.",
 		"type_code": "villain"
@@ -1920,8 +1928,8 @@
 		"quantity": 1,
 		"set_code": "magneto_villain",
 		"set_position": 4,
-		"stage": 1,
-		"text": "<b>Contents:</b> Magneto (I) and Magneto (II). <i>(Magneto (II) and Magneto (III) for expert mode.)</i> Magneto and Standard sets. One modular set (<i>Acolytes</i>).\n<b>Setup:</b> Set the Orbital Decay side scheme aside. Reveal the Boarding Party side scheme.",
+		"stage": "1A",
+		"text": "<b>Contents</b>: Magneto (I) and Magneto (II). <i>(Magneto (II) and Magneto (III) for expert mode.)</i> Magneto and Standard sets. One modular set (<i>Acolytes</i>).\n<b>Setup</b>: Set the Orbital Decay side scheme aside. Reveal the Boarding Party side scheme.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -1937,7 +1945,7 @@
 		"quantity": 1,
 		"set_code": "magneto_villain",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1B",
 		"text": "<b>Forced Response</b>: After you place a magnet counter on this scheme, if there are at least 3 magnet counters here, discard cards from the encounter deck until a [[Magnetic]] card is discarded. Reveal that card, then remove 3 magnet counters from this scheme.",
 		"threat": 5,
 		"type_code": "main_scheme"
@@ -1953,7 +1961,7 @@
 		"quantity": 1,
 		"set_code": "magneto_villain",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2A",
 		"text": "<b>When Revealed</b>: Place 1 magnet counter here. If Sabotage Master Mold is not in the victory display, the first player searches the encounter deck and discard pile for a copy of the M-Type Sentinel minion and reveals it.",
 		"type_code": "main_scheme"
 	},
@@ -1970,7 +1978,7 @@
 		"quantity": 1,
 		"set_code": "magneto_villain",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2B",
 		"text": "<b>Forced Response</b>: After you place a magnet counter on this scheme, if there are at least 3 magnet counters here, discard cards from the encounter deck until a [[Magnetic]] card is discarded. Reveal that card, then remove 3 magnet counters from this scheme.",
 		"threat": 6,
 		"type_code": "main_scheme"
@@ -1986,7 +1994,7 @@
 		"quantity": 1,
 		"set_code": "magneto_villain",
 		"set_position": 6,
-		"stage": 3,
+		"stage": "3A",
 		"text": "<b>When Revealed</b>: Place 2 magnet counters here. If Physical Strain is not attached to Magneto, the first player searches the encounter deck and discard pile for a [[Magnetic]] attachment and reveals it.",
 		"type_code": "main_scheme"
 	},
@@ -2003,7 +2011,7 @@
 		"quantity": 1,
 		"set_code": "magneto_villain",
 		"set_position": 6,
-		"stage": 3,
+		"stage": "3B",
 		"text": "<b>Forced Response</b>: After you place a magnet counter on this scheme, if there are at least 3 magnet counters here, discard cards from the encounter deck until a [[Magnetic]] card is discarded. Reveal that card, then remove 3 magnet counters from this scheme.\n<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 7,
 		"type_code": "main_scheme"

--- a/pack/next_evol_encounter.json
+++ b/pack/next_evol_encounter.json
@@ -208,7 +208,7 @@
         "scheme": 1,
         "set_code": "marauders",
         "set_position": 1,
-        "stage": null,
+        "stage": "A",
         "text": "[star] <b>Forced Interrupt</b>: When Arclight attacks you or an ally you control, choose:\n\u2022 Confuse a character you control.\n\u2022 Arclight gets +2 ATK for this attack.",
         "traits": "Brute. Marauder.",
         "type_code": "villain"
@@ -231,7 +231,7 @@
         "scheme": 2,
         "set_code": "marauders",
         "set_position": 1,
-        "stage": null,
+        "stage": "B",
         "text": "[star] <b>Forced Interrupt</b>: When Arclight attacks you or an ally you control, choose:\n\u2022 Confuse the character you control with the highest THW.\n\u2022 Arclight gets +2 ATK for this attack.",
         "traits": "Brute. Marauder.",
         "type_code": "villain"
@@ -254,7 +254,7 @@
         "scheme": 0,
         "set_code": "marauders",
         "set_position": 2,
-        "stage": null,
+        "stage": "A",
         "text": "[star] <b>Forced Interrupt</b>: When Blockbuster attacks you or an ally you control, choose:\n\u2022 Give Blockbuster a tough status card.\n\u2022 Blockbuster gets +2 ATK for this attack.",
         "traits": "Brute. Marauder.",
         "type_code": "villain"
@@ -277,7 +277,7 @@
         "scheme": 1,
         "set_code": "marauders",
         "set_position": 2,
-        "stage": null,
+        "stage": "B",
         "text": "[star] <b>Forced Interrupt</b>: When Blockbuster attacks you or an ally you control, choose:\n\u2022 Give Blockbuster a tough status card.\n\u2022 Blockbuster gets +2 ATK for this attack and this attack gains overkill.",
         "traits": "Brute. Marauder.",
         "type_code": "villain"
@@ -300,7 +300,7 @@
         "scheme": 1,
         "set_code": "marauders",
         "set_position": 3,
-        "stage": null,
+        "stage": "A",
         "text": "[star] <b>Forced Interrupt</b>: When Chimera attacks you or an ally you control, choose:\n\u2022 Spend a [mental] resource.\n\u2022 Chimera gets +2 ATK for this attack.",
         "traits": "Marauder. Psionic.",
         "type_code": "villain"
@@ -323,7 +323,7 @@
         "scheme": 2,
         "set_code": "marauders",
         "set_position": 3,
-        "stage": null,
+        "stage": "B",
         "text": "[star] <b>Forced Interrupt</b>: When Chimera attacks you or an ally you control, choose:\n\u2022 Spend [mental][mental] resources.\n\u2022 Chimera gets +2 ATK for this attack.",
         "traits": "Marauder. Psionic.",
         "type_code": "villain"
@@ -346,7 +346,7 @@
         "scheme": 1,
         "set_code": "marauders",
         "set_position": 4,
-        "stage": null,
+        "stage": "A",
         "text": "[star] <b>Forced Interrupt</b>: When Greycrow attacks you or an ally you control, choose:\n\u2022 Discard the highest-cost card you control.\n\u2022 Greycrow gets +X ATK for this attack, where X is the printed cost of the highest-cost card you control.",
         "traits": "Marauder. Mercenary.",
         "type_code": "villain"
@@ -369,7 +369,7 @@
         "scheme": 2,
         "set_code": "marauders",
         "set_position": 4,
-        "stage": null,
+        "stage": "B",
         "text": "[star] <b>Forced Interrupt</b>: When Greycrow attacks you or an ally you control, choose:\n\u2022 Discard each card you control with the highest cost.\n\u2022 Greycrow gets +X ATK for this attack, where X is the printed cost of the highest-cost card you control.",
         "traits": "Marauder. Mercenary.",
         "type_code": "villain"
@@ -392,7 +392,7 @@
         "scheme": 0,
         "set_code": "marauders",
         "set_position": 5,
-        "stage": null,
+        "stage": "A",
         "text": "[star] <b>Forced Interrupt</b>: When Harpoon attacks you or an ally you control, choose:\n\u2022 Take 2 indirect damage.\n\u2022 Give Harpoon 1 additional facedown boost card for this attack.",
         "traits": "Brute. Marauder.",
         "type_code": "villain"
@@ -415,7 +415,7 @@
         "scheme": 1,
         "set_code": "marauders",
         "set_position": 5,
-        "stage": null,
+        "stage": "B",
         "text": "[star] <b>Forced Interrupt</b>: When Harpoon attacks you or an ally you control, choose:\n\u2022 Take 3 indirect damage.\n\u2022 Give Harpoon 1 additional facedown boost card for this attack. This attack gains overkill.",
         "traits": "Brute. Marauder.",
         "type_code": "villain"
@@ -438,7 +438,7 @@
         "scheme": 1,
         "set_code": "marauders",
         "set_position": 6,
-        "stage": null,
+        "stage": "A",
         "text": "[star] <b>Forced Interrupt</b>: When Riptide attacks you or an ally you control, choose:\n\u2022 Place 2 threat on the main scheme and 1 threat on each side scheme.\n\u2022 Riptide gets +2 ATK for this attack.",
         "traits": "Assassin. Marauder.",
         "type_code": "villain"
@@ -461,7 +461,7 @@
         "scheme": 2,
         "set_code": "marauders",
         "set_position": 6,
-        "stage": null,
+        "stage": "B",
         "text": "[star] <b>Forced Interrupt</b>: When Riptide attacks you or an ally you control, choose:\n\u2022 Place 3 threat on the main scheme and 1 threat on each side scheme.\n\u2022 Riptide gets +2 ATK for this attack and this attack gains ranged and piercing.",
         "traits": "Assassin. Marauder.",
         "type_code": "villain"
@@ -484,7 +484,7 @@
         "scheme": 2,
         "set_code": "marauders",
         "set_position": 7,
-        "stage": null,
+        "stage": "A",
         "text": "[star] <b>Forced Interrupt</b>: When Vertigo attacks you or an ally you control, choose:\n\u2022 Stun a character you control.\n\u2022 Vertigo gets +2 ATK for this attack.",
         "traits": "Marauder. Mutate.",
         "type_code": "villain"
@@ -507,7 +507,7 @@
         "scheme": 3,
         "set_code": "marauders",
         "set_position": 7,
-        "stage": null,
+        "stage": "B",
         "text": "[star] <b>Forced Interrupt</b>: When Vertigo attacks you or an ally you control, choose:\n\u2022 Stun the character you control with the highest ATK.\n\u2022 Vertigo gets +2 ATK for this attack.",
         "traits": "Marauder. Mutate.",
         "type_code": "villain"
@@ -524,7 +524,7 @@
         "quantity": 1,
         "set_code": "morlock_siege",
         "set_position": 1,
-        "stage": 1,
+        "stage": "1A",
         "text": "<b>Contents</b>: Marauders on side A <i>(side B for expert mode)</i>. Morlock Siege and Standard encounter sets. Two modular encounter sets <i>(Military Grade and Mutant Slayers)</i>.\n<b>Setup</b>: Put the Routed environment into play. Set the Hide! treachery and each Morlock ally aside. Shuffle the villains together <i>(without looking)</i> to create the villain deck. The top card of this deck is in play.",
         "type_code": "main_scheme"
     },
@@ -543,7 +543,7 @@
         "quantity": 1,
         "set_code": "morlock_siege",
         "set_position": 1,
-        "stage": 1,
+        "stage": "1B",
         "text": "[star] <b>Forced Response</b>: After resolving step one of the villain phase, place 1 knock counter here. If there are at least 3 knock counters here, advance to stage 2A.\n<b>If there are 3 villains under Routed, the players win the game.</b>",
         "threat": 6,
         "type_code": "main_scheme"
@@ -560,7 +560,7 @@
         "quantity": 1,
         "set_code": "morlock_siege",
         "set_position": 2,
-        "stage": 2,
+        "stage": "2A",
         "text": "<b>When Revealed</b>: Each player puts 1 set-aside Morlock ally into play under their control (2 set-aside Morlock allies instead if this is a single-player game). Shuffle the Hide! treachery into the encounter deck. If the previous stage was advanced by knock counters, give each Morlock ally a tough status card.",
         "type_code": "main_scheme"
     },
@@ -579,7 +579,7 @@
         "quantity": 1,
         "set_code": "morlock_siege",
         "set_position": 2,
-        "stage": 2,
+        "stage": "2B",
         "text": "<b>Action</b>: Exhaust a [[MORLOCK]] ally \u2192 shuffle Hide! from the encounter discard pile into the encounter deck.\n<b>If there are 3 villains under Routed, the players win the game.\nIf this stage is completed or there are no Morlock allies in play, the players lose the game.</b>",
         "threat": 8,
         "type_code": "main_scheme"
@@ -1043,7 +1043,7 @@
         "quantity": 1,
         "set_code": "on_the_run",
         "set_position": 1,
-        "stage": 1,
+        "stage": "1A",
         "text": "<b>Contents</b>: Marauders on side A <i>(side B for expert mode)</i>. On the Run, Mutant Slayers, and Standard encounter sets. Two modular encounter sets <i>(Military Grade and Nasty Boys)</i>.\n<b>Setup</b>: Put 1 random [[MARAUDER]] villain into play. Remove the minion with the same title as the villain, along with each other villain, from the game. Attach the Hope's Captor attachment to the villain, [[CONFIDENT]] side up.",
         "type_code": "main_scheme"
     },
@@ -1061,7 +1061,7 @@
         "quantity": 1,
         "set_code": "on_the_run",
         "set_position": 1,
-        "stage": 1,
+        "stage": "1B",
         "text": "Each [[MARAUDER]] minion gains steady.\n<b>When Revealed</b>: Each player searches the encounter deck for a [[MARAUDER]] minion and puts it into play engaged with them. <i>(Shuffle.)</i>\n<b>If this stage is completed, the players lose the game.</b>",
         "threat": 8,
         "type_code": "main_scheme"
@@ -1079,7 +1079,7 @@
         "quantity": 1,
         "set_code": "on_the_run",
         "set_position": 2,
-        "stage": 2,
+        "stage": "2A",
         "text": "<b>When Revealed</b>: Each player searches the encounter deck and discard pile for a [[MARAUDER]] minion and puts that minion into play engaged with them. <i>(Shuffle.)</i> Give each [[MARAUDER]] enemy a tough status card.",
         "type_code": "main_scheme"
     },
@@ -1097,7 +1097,7 @@
         "quantity": 1,
         "set_code": "on_the_run",
         "set_position": 2,
-        "stage": 2,
+        "stage": "2B",
         "text": "Each [[MARAUDER]] minion gains guard and steady. In expert mode, the villain gains steady.\n<b>If the villain is defeated, the players win the game.</b>\n<b>If this stage is completed, the players lose the game.</b>",
         "threat": 9,
         "type_code": "main_scheme"
@@ -1379,7 +1379,7 @@
         "scheme": 1,
         "set_code": "juggernaut",
         "set_position": 1,
-        "stage": 1,
+        "stage": "I",
         "text": "[star] Juggernaut gets +1 ATK for each momentum counter here.\n<b>When Revealed</b>: Place 1 momentum counter here. Give Juggernaut a tough status card.",
         "traits": "Brute.",
         "type_code": "villain"
@@ -1401,7 +1401,7 @@
         "scheme": 1,
         "set_code": "juggernaut",
         "set_position": 2,
-        "stage": 2,
+        "stage": "II",
         "text": "[star] Juggernaut gets +1 ATK for each momentum counter here.\n<b>When Revealed</b>: Place 1 momentum counter here. If Juggernaut Exposed is in play, flip it. Otherwise, give Juggernaut a tough status card.",
         "traits": "Brute.",
         "type_code": "villain"
@@ -1423,7 +1423,7 @@
         "scheme": 2,
         "set_code": "juggernaut",
         "set_position": 3,
-        "stage": 3,
+        "stage": "III",
         "text": "[star] Juggernaut gets +1 ATK for each momentum counter here.\n<b>When Revealed</b>: Search the encounter deck and discard pile for Head of Steam and reveal it. <i>(Shuffle.)</i> If Juggernaut Exposed is in play, flip it. Otherwise, give Juggernaut a tough status card.",
         "traits": "Brute.",
         "type_code": "villain"
@@ -1440,7 +1440,7 @@
         "quantity": 1,
         "set_code": "juggernaut",
         "set_position": 4,
-        "stage": 1,
+        "stage": "1A",
         "text": "<b>Contents</b>: Juggernaut (I) and Juggernaut (II) <i>(Juggernaut (II) and Juggernaut (III) instead for expert mode)</i>. Juggernaut, Hope Summers, and Standard encounter sets. One modular encounter set <i>(Black Tom Cassidy)</i>.\n<b>Setup</b>: Attach Juggernaut's Helmet to Juggernaut. Put Home Summers into play under the first player's control.",
         "type_code": "main_scheme"
     },
@@ -1458,7 +1458,7 @@
         "quantity": 1,
         "set_code": "juggernaut",
         "set_position": 4,
-        "stage": 1,
+        "stage": "1B",
         "text": "[star] <b>Forced Interrupt</b>: When this scheme would be completed, instead do each of the following:\n1. Remove all threat from here.\n2. If Juggernaut Exposed is in play, flip it.\n3. Place 1 momentum counter on Juggernaut.\n4. Juggernaut attacks each player in player order <i>(even if they are in alter-ego form)</i>.",
         "threat": 7,
         "threat_star": true,
@@ -1733,7 +1733,7 @@
         "scheme": 2,
         "set_code": "mister_sinister",
         "set_position": 1,
-        "stage": 1,
+        "stage": "I",
         "text": "<b>Forced Response</b>: After a status card is placed on Mister Sinister, place 1 threat on the main scheme.",
         "traits": "Genius.",
         "type_code": "villain"
@@ -1754,7 +1754,7 @@
         "scheme": 2,
         "set_code": "mister_sinister",
         "set_position": 2,
-        "stage": 2,
+        "stage": "II",
         "text": "<b>When Revealed</b>: Place 1[per_hero] threat on the main scheme (2[per_hero] threat instead if Mister Sinister has fewer than 2 [[SUPERPOWER]] attachments).\n<b>Forced Response</b>: After a status card is placed on Mister Sinister, place 2 threat on the main scheme.",
         "traits": "Genius.",
         "type_code": "villain"
@@ -1775,7 +1775,7 @@
         "scheme": 3,
         "set_code": "mister_sinister",
         "set_position": 3,
-        "stage": 3,
+        "stage": "III",
         "text": "<b>When Revealed</b>: Place 2[per_hero] threat on the main scheme (3[per_hero] threat instead if Mister Sinister has fewer than 2 [[SUPERPOWER]] attachments).\n<b>Forced Response</b>: After a status card is placed on Mister Sinister, place 3 threat on the main scheme.",
         "traits": "Genius.",
         "type_code": "villain"
@@ -1792,7 +1792,7 @@
         "quantity": 1,
         "set_code": "mister_sinister",
         "set_position": 4,
-        "stage": 1,
+        "stage": "1A",
         "text": "<b>Contents</b>: Mister Sinister (I) and Mister Sinister (II) <i>(Mister Sinister (II) and Mister Sinister (III) instead for expert mode)</i>. Mister Sinister, Flight, Super Strength, Telepathy, Hope Summers, and Standard encounter sets. One modular encounter set <i>(Nasty Boys)</i>.\n<b>Setup</b>: Set aside the Flight, Super Strength, and Telepathy encounter sets. Put Hope Summers into play under the first player's control.",
         "type_code": "main_scheme"
     },
@@ -1809,7 +1809,7 @@
         "quantity": 1,
         "set_code": "mister_sinister",
         "set_position": 4,
-        "stage": 1,
+        "stage": "1B",
         "text": "<b>When Revealed</b>: Remove 1 random stage 2 from the game. Then advance to a random stage 2A.",
         "type_code": "main_scheme"
     },
@@ -1826,7 +1826,7 @@
         "quantity": 1,
         "set_code": "mister_sinister",
         "set_position": 5,
-        "stage": 2,
+        "stage": "2A",
         "type_code": "main_scheme"
     },
     {
@@ -1843,7 +1843,7 @@
         "quantity": 1,
         "set_code": "mister_sinister",
         "set_position": 5,
-        "stage": 2,
+        "stage": "2B",
         "text": "<b>When Revealed</b>: Attach the Flight attachment to Mister Sinister and shuffle the rest of the Flight encounter set into the encounter deck.\n<b>When Completed</b>: Advance to the other stage 2A. If you cannot, advance to stage 3A.",
         "threat": 5,
         "type_code": "main_scheme"
@@ -1861,7 +1861,7 @@
         "quantity": 1,
         "set_code": "mister_sinister",
         "set_position": 6,
-        "stage": 2,
+        "stage": "2A",
         "type_code": "main_scheme"
     },
     {
@@ -1878,7 +1878,7 @@
         "quantity": 1,
         "set_code": "mister_sinister",
         "set_position": 6,
-        "stage": 2,
+        "stage": "2B",
         "text": "<b>When Revealed</b>: Attach the Super Strength attachment to Mister Sinister and shuffle the rest of the Super Strength encounter set into the encounter deck.\n<b>When Completed</b>: Advance to the other stage 2A. If you cannot, advance to stage 3A.",
         "threat": 5,
         "type_code": "main_scheme"
@@ -1896,7 +1896,7 @@
         "quantity": 1,
         "set_code": "mister_sinister",
         "set_position": 7,
-        "stage": 2,
+        "stage": "2A",
         "type_code": "main_scheme"
     },
     {
@@ -1913,7 +1913,7 @@
         "quantity": 1,
         "set_code": "mister_sinister",
         "set_position": 7,
-        "stage": 2,
+        "stage": "2B",
         "text": "<b>When Revealed</b>: Attach the Telepathy attachment to Mister Sinister and shuffle the rest of the Telepathy encounter set into the encounter deck.\n<b>When Completed</b>: Advance to the other stage 2A. If you cannot, advance to stage 3A.",
         "threat": 5,
         "type_code": "main_scheme"
@@ -1931,7 +1931,7 @@
         "quantity": 1,
         "set_code": "mister_sinister",
         "set_position": 8,
-        "stage": 3,
+        "stage": "3A",
         "text": "<b>When Revealed</b>: Deal each player 1 facedown encounter card.",
         "type_code": "main_scheme"
     },
@@ -1951,7 +1951,7 @@
         "quantity": 1,
         "set_code": "mister_sinister",
         "set_position": 8,
-        "stage": 3,
+        "stage": "3B",
         "text": "<b>Forced Interrupt</b>: When Mister Sinister attacks, he attacks Hope Summers instead. <i>(Other characters may defend the attack.)</i>\n<b>If this stage is completed, the players lose the game.</b>",
         "threat": 7,
         "type_code": "main_scheme"
@@ -2281,7 +2281,7 @@
         "scheme": 1,
         "set_code": "stryfe",
         "set_position": 1,
-        "stage": 1,
+        "stage": "I",
         "text": "[star] While Stryfe is attacking you, he gets +X ATK, where X is the number of cards of the most common type in your hand.",
         "traits": "Mutant Liberation Front. Psionic.",
         "type_code": "villain"
@@ -2303,7 +2303,7 @@
         "scheme": 1,
         "set_code": "stryfe",
         "set_position": 2,
-        "stage": 2,
+        "stage": "II",
         "text": "[star] While Stryfe is attacking you, he gets +X ATK, where X is the number of cards of the most common type in your hand.\n<b>When Revealed</b>: Each player discards cards from the top of the encounter deck until a [[PSIONIC]] attachment is discarded and reveals that card.",
         "traits": "Mutant Liberation Front. Psionic.",
         "type_code": "villain"
@@ -2325,7 +2325,7 @@
         "scheme": 2,
         "set_code": "stryfe",
         "set_position": 3,
-        "stage": 3,
+        "stage": "III",
         "text": "[star] While Stryfe is attacking you, he gets +X ATK, where X is the number of cards of the most common type in your hand.\n<b>Forced Response</b>: After you attack Stryfe, take X damage, where X is the number of cards of the most common type in your hand.",
         "traits": "Mutant Liberation Front. Psionic.",
         "type_code": "villain"
@@ -2341,7 +2341,7 @@
         "quantity": 1,
         "set_code": "stryfe",
         "set_position": 4,
-        "stage": 1,
+        "stage": "1A",
         "text": "<b>Contents</b>: Stryfe (I) and Stryfe (II) <i>(Stryfe (II) and Stryfe (III) instead for expert mode)</i>. Stryfe, Hope Summers, and Standard encounter sets. Two modular encounter sets <i>(Extreme Measures and Mutant Insurrection)</i>.\n<b>Setup</b>: Put Hope Summers into play under the first player's control. Reveal Stryfe's Grasp.",
         "type_code": "main_scheme"
     },
@@ -2361,7 +2361,7 @@
         "quantity": 1,
         "set_code": "stryfe",
         "set_position": 4,
-        "stage": 1,
+        "stage": "1B",
         "text": "[star] <b>Forced Response</b>: After resolving step one of the villain phase, each player places X threat here, where X is the number of cards of the most common type in their hand. Each player may discard 1 card from their hand before calculating the value of X.\n<b>If this stage is completed, the players lose the game.</b>",
         "threat": 9,
         "type_code": "main_scheme"
@@ -2379,7 +2379,7 @@
         "quantity": 1,
         "set_code": "stryfe",
         "set_position": 5,
-        "stage": 2,
+        "stage": "2A",
         "type_code": "main_scheme"
     },
     {
@@ -2398,7 +2398,7 @@
         "quantity": 1,
         "set_code": "stryfe",
         "set_position": 5,
-        "stage": 2,
+        "stage": "2B",
         "text": "Stryfe gains stalwart.\nEach identity gets +2 hand size. Increase the resource cost to play each player card by 1.\n<b>If this stage is completed, the players lose the game.</b>",
         "threat": 8,
         "type_code": "main_scheme"

--- a/pack/sm_encounter.json
+++ b/pack/sm_encounter.json
@@ -177,7 +177,7 @@
 		"scheme": 1,
 		"set_code": "sandman",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "<i>Sand Blast</i> — [star] <b>Forced Interrupt</b>: When Sandman attacks you, that attack deals indirect damage. If your identity takes any amount of damage from that attack, resolve the \"<i>Surging Sands</i>\" ability on City Streets.",
 		"traits": "Criminal.",
 		"type_code": "villain"
@@ -198,7 +198,7 @@
 		"scheme": 1,
 		"set_code": "sandman",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "II",
 		"text": "<b>When Revealed</b>: Resolve the \"<i>Surging Sands</i>\" ability on City Streets.\n<i>Sand Blast</i> — [star] <b>Forced Interrupt</b>: When Sandman attacks you, that attack deals indirect damage. If your identity takes any amount of damage from that attack, resolve the \"<i>Surging Sands</i>\" ability on City Streets.",
 		"traits": "Criminal.",
 		"type_code": "villain"
@@ -219,7 +219,7 @@
 		"scheme": 1,
 		"set_code": "sandman",
 		"set_position": 3,
-		"stage": 3,
+		"stage": "III",
 		"text": "<b>When Revealed</b>: Place 1 sand counter on City Streets. Resolve its \"<i>Surging Sands</i>\" ability.\n<i>Sand Wave</i> — [star] <b>Forced Interrupt</b>: When Sandman attacks you, that attack gains overkill. If your identity takes any amount of damage from that attack, resolve the \"<i>Surging Sands</i>\" ability on City Streets.",
 		"traits": "Criminal.",
 		"type_code": "villain"
@@ -235,7 +235,7 @@
 		"quantity": 1,
 		"set_code": "sandman",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1A",
 		"text": "<b>Contents</b>: Sandman (I) and Sandman (II). <i>(Sandman (II) and Sandman (III) instead for expert mode.)</i> Sandman, City in Chaos, and Standard encounter sets. One modular encounter set <i>(Down to Earth)</i>.\n<b>Setup</b>: Search the encounter deck for the City Streets environment and put it into play. Place 4 sand counters on it.",
 		"type_code": "main_scheme"
 	},
@@ -252,7 +252,7 @@
 		"quantity": 1,
 		"set_code": "sandman",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1B",
 		"text": "<b>Forced Response</b>: After an acceleration token is placed on this scheme, deal 3 indirect damage to the first player.\n<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 9,
 		"type_code": "main_scheme"
@@ -397,7 +397,7 @@
 		"scheme": 1,
 		"set_code": "venom",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "Toughness. (This character enters play with a tough status card.)\n<i>Vengeance</i> — <b>Forced Response</b>: After you or an ally you control attacks and damages Venom, place 1 facedown boost card on your identity.",
 		"traits": "Symbiote.",
 		"type_code": "villain"
@@ -418,7 +418,7 @@
 		"scheme": 2,
 		"set_code": "venom",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "II",
 		"text": "Toughness. Steady.\n<b>When Revealed</b>: Search the encounter deck and discard pile for the Tooth and Nail side scheme and put it into play. <i>(Shuffle.)</i>\n<i>Vengeance</i> — <b>Forced Response</b>: After you or an ally you control attacks and damages Venom, place 1 facedown boost card on your identity.",
 		"traits": "Symbiote.",
 		"type_code": "villain"
@@ -439,7 +439,7 @@
 		"scheme": 2,
 		"set_code": "venom",
 		"set_position": 3,
-		"stage": 3,
+		"stage": "III",
 		"text": "Retaliate 1. Steady. Toughness.\n<b>When Revealed</b>: Place 2 facedown boost cards on each identity.\n<i>Retribution</i> — <b>Forced Response</b>: After you or an ally you control attacks and damages Venom, place 1 facedown boost card on your identity (2 facedown boost cards instead if this is the first attack this turn).",
 		"traits": "Symbiote.",
 		"type_code": "villain"
@@ -456,7 +456,7 @@
 		"quantity": 1,
 		"set_code": "venom",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1A",
 		"text": "<b>Contents</b>: Venom (I) and Venom (II). <i>(Venom (II) and Venom (III) instead for expert mode.)</i> Venom, Symbiotic Strength, and Standard encounter sets. One modular encounter set <i>(Down to Earth.)</i>\n<b>Setup</b>: Put the Bell Tower environment into play, [[QUIET]] side faceup.",
 		"threat": null,
 		"type_code": "main_scheme"
@@ -474,7 +474,7 @@
 		"quantity": 1,
 		"set_code": "venom",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1B",
 		"text": "<b>Forced Interrupt</b>: When Venom activates against you, move each facedown boost card from your identity to Venom.\n<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 10,
 		"type_code": "main_scheme"
@@ -625,7 +625,7 @@
 		"scheme_star": true,
 		"set_code": "mysterio",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "<i>Seeds of Fear</i> — [star] <b>Forced Response</b>: After you resolve a boost card during Mysterio's activation, place that card in your discard pile if it has the [[illusion]] trait.",
 		"traits": "Criminal.",
 		"type_code": "villain"
@@ -648,7 +648,7 @@
 		"scheme_star": true,
 		"set_code": "mysterio",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "II",
 		"text": "<b>When Revealed</b>: In player order, shuffle the top card of the encounter deck into each player's deck.\n<i>Creeping Fear</i> — [star] <b>Forced Response</b>: After you resolve a boost card during Mysterio's activation, place that card on the bottom of your deck if it has the [[illusion]] trait.",
 		"traits": "Criminal.",
 		"type_code": "villain"
@@ -671,7 +671,7 @@
 		"scheme_star": true,
 		"set_code": "mysterio",
 		"set_position": 3,
-		"stage": 3,
+		"stage": "III",
 		"text": "<b>When Revealed</b>: Discard the top 5 cards of each player's deck.\n<i>Bound by Fear</i> — [star] <b>Forced Response</b>: After you resolve a boost card during Mysterio's activation, place that card on the top of your deck if it has the [[illusion]] trait.",
 		"traits": "Criminal.",
 		"type_code": "villain"
@@ -688,7 +688,7 @@
 		"quantity": 1,
 		"set_code": "mysterio",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1A",
 		"text": "<b>Contents</b>: Mysterio (I) and Mysterio (II). <i>(Mysterio (II) and Mysterio (III) instead for expert mode.)</i> Mysterio, Personal Nightmare, and Standard encounter sets. One modular encounter set <i>(Whispers of Paranoia.)</i>\n<b>Setup</b>: Put a shifting Apparition minion into play engaged with each player. <i>(Shuffle.)</i>",
 		"type_code": "main_scheme"
 	},
@@ -706,7 +706,7 @@
 		"quantity": 1,
 		"set_code": "mysterio",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1B",
 		"text": "<b>Forced Interrupt</b>: When you would draw or discard an encounter card from your deck, deal it to yourself as a facedown encounter card → draw 1 card.",
 		"threat": 8,
 		"type_code": "main_scheme"
@@ -723,7 +723,7 @@
 		"quantity": 1,
 		"set_code": "mysterio",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2A",
 		"text": "<b>When Revealed</b>: In player order, shuffle the top 2 cards of the encounter deck into each player's deck.",
 		"type_code": "main_scheme"
 	},
@@ -741,7 +741,7 @@
 		"quantity": 1,
 		"set_code": "mysterio",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2B",
 		"text": "<b>Forced Interrupt</b>: When you would draw or discard an encounter card from your deck, deal it to yourself as a facedown encounter card → draw 1 card.\n<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 9,
 		"type_code": "main_scheme"
@@ -839,7 +839,7 @@
 		"scheme": 2,
 		"set_code": "sinister_six",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "[star] <b>Forced Response</b>: After Doctor Octopus attacks and damages you, place 1 threat on each scheme. Move the active counter to the next villain in the activation order.\n<b>When Defeated</b>: Remove 4 threat from a side scheme (7 threat instead if no other villain is in play). Set this villain aside.",
 		"traits": "Activation Order 1",
 		"type_code": "villain"
@@ -860,7 +860,7 @@
 		"scheme": 2,
 		"set_code": "sinister_six",
 		"set_position": 2,
-		"stage": 1,
+		"stage": "I",
 		"text": "[star] <b>Forced Response</b>: After Electro attacks and damages you, discard the top 7 cards of your deck. Move the active counter to the next villain in the activation order.\n<b>When Defeated</b>: Remove 4 threat from a side scheme (7 threat instead if no other villain is in play). Set this villain aside.",
 		"traits": "Activation Order 2",
 		"type_code": "villain"
@@ -881,7 +881,7 @@
 		"scheme": 2,
 		"set_code": "sinister_six",
 		"set_position": 3,
-		"stage": 1,
+		"stage": "I",
 		"text": "[star] <b>Forced Response</b>: After Hobgoblin attacks and damages you, take 2 indirect damage. Move the active counter to the next villain in the activation order.\n<b>When Defeated</b>: Remove 4 threat from a side scheme (7 threat instead if no other villain is in play). Set this villain aside.",
 		"traits": "Activation Order 3",
 		"type_code": "villain"
@@ -902,7 +902,7 @@
 		"scheme": 1,
 		"set_code": "sinister_six",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "I",
 		"text": "[star] <b>Forced Response</b>: After Kraven the Hunter attacks and damages you, choose and discard 1 support or upgrade you control. Move the active counter to the next villain in the activation order.\n<b>When Defeated</b>: Remove 4 threat from a side scheme (7 threat instead if no other villain is in play). Set this villain aside.",
 		"traits": "Activation Order 4",
 		"type_code": "villain"
@@ -923,7 +923,7 @@
 		"scheme": 0,
 		"set_code": "sinister_six",
 		"set_position": 5,
-		"stage": 1,
+		"stage": "I",
 		"text": "[star] <b>Forced Response</b>: After Scorpion attacks and damages you, stun a character you control. Move the active counter to the next villain in the activation order.\n<b>When Defeated</b>: Remove 4 threat from a side scheme (7 threat instead if no other villain is in play). Set this villain aside.",
 		"traits": "Activation Order 5",
 		"type_code": "villain"
@@ -944,7 +944,7 @@
 		"scheme": 1,
 		"set_code": "sinister_six",
 		"set_position": 6,
-		"stage": 1,
+		"stage": "I",
 		"text": "[star] <b>Forced Response</b>: After Vulture attacks and damages you, choose and discard 1 card from your hand. Move the active counter to the next villain in the activation order.\n<b>When Defeated</b>: Remove 4 threat from a side scheme (7 threat instead if no other villain is in play). Set this villain aside.",
 		"traits": "Activation Order 6",
 		"type_code": "villain"
@@ -961,7 +961,7 @@
 		"quantity": 1,
 		"set_code": "sinister_six",
 		"set_position": 7,
-		"stage": 1,
+		"stage": "1A",
 		"text": "<b>Contents</b>: Doctor Octopus, Electro, Hobgoblin, Kraven the Hunter, Scorpion, and Vulture. The Sinister Six, Guerrilla Tactics, and Standard encounter sets.\n<b>Setup</b>: Choose X villains at random, where X is 1 more than the number of players. Put those villains into play, place the active counter on the villain with the lowest activation order value, and set the other villains aside. Put the Light at the End side scheme into play, [[trap!]] side faceup.",
 		"type_code": "main_scheme"
 	},
@@ -979,7 +979,7 @@
 		"quantity": 1,
 		"set_code": "sinister_six",
 		"set_position": 7,
-		"stage": 1,
+		"stage": "1B",
 		"text": "Ambush! — <b>Special</b>: Choose a set-aside villain at random, put that villain into play, and place the active counter on it. (In expert mode, place 2 threat on Light at the End).\n<b>Forced Interrupt</b>: When a villain would activate, if no villain is in play, resolve this card's \"<i>Ambush!</i>\" ability. Continue that activation.",
 		"threat": 8,
 		"type_code": "main_scheme"
@@ -996,7 +996,7 @@
 		"quantity": 1,
 		"set_code": "sinister_six",
 		"set_position": 8,
-		"stage": 2,
+		"stage": "2A",
 		"text": "<b>When Revealed</b>: Choose a set-aside villain at random, put that villain into play, and place the active counter on it <i>(even if another villain has the counter)</i>. If no villain was put into play this way or this is expert mode, deal the first player 1 facedown encounter card.",
 		"threat": null,
 		"type_code": "main_scheme"
@@ -1014,7 +1014,7 @@
 		"quantity": 1,
 		"set_code": "sinister_six",
 		"set_position": 8,
-		"stage": 2,
+		"stage": "2B",
 		"text": "<i>Ambush!</i> — <b>Special</b>: Choose a set-aside villain at random, put that villain into play, and place the active counter on it. (In expert mode, place 2 threat on Light at the End).\n<b>Forced Interrupt</b> When a villain would activate, if no villain is in play, resolve this card's \"<i>Ambush!</i>\" ability. Continue that activation.\n<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 7,
 		"type_code": "main_scheme"
@@ -1220,7 +1220,7 @@
 		"scheme_star": true,
 		"set_code": "venom_goblin",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "Steady.\n<i>Infest the City</i> — [star] <b>Forced Response</b>: After Venom Goblin activates against you, move the glider counter to the main scheme with the least threat. Choose to either place 2 threat on that scheme or resolve its \"<b>Special</b>\" ability.",
 		"traits": "Goblin. Symbiote.",
 		"type_code": "villain"
@@ -1242,7 +1242,7 @@
 		"scheme_star": true,
 		"set_code": "venom_goblin",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "II",
 		"text": "Steady. Toughness.\n<b>When Revealed</b>: Deal 2 facedown encounter cards to each player.\n<i>Claim the Throne</i> — [star] <b>Forced Response</b>: After Venom Goblin activates against you, move the glider counter to the main scheme with the least threat. Resolve its \"<b>Special</b>\" ability.",
 		"traits": "Goblin. Symbiote.",
 		"type_code": "villain"
@@ -1264,7 +1264,7 @@
 		"scheme_star": true,
 		"set_code": "venom_goblin",
 		"set_position": 3,
-		"stage": 3,
+		"stage": "III",
 		"text": "Retaliate 1. Stalwart. Toughness.\n<b>When Revealed</b>: Deal 3 facedown encounter cards to each player.\n<i>Reign of Terror</i> — [star] <b>Forced Response</b>: After Venom Goblin activates against you, move the glider counter to the main scheme with the least threat. Place 1 threat on that scheme and resolve its \"<b>Special</b>\" ability.",
 		"traits": "Goblin. Symbiote.",
 		"type_code": "villain"
@@ -1281,7 +1281,7 @@
 		"quantity": 1,
 		"set_code": "venom_goblin",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "A",
 		"text": "<b>Contents</b>: Venom Goblin (I) and Venom Goblin (II) <i>(Venom Goblin (II) and Venom Goblin (III) for expert mode.)</i> Venom Goblin, Symbiotic Strength, and Standard encounter sets. One modular encounter set <i>(Goblin Gear)</i>.\n<b>Setup</b>: Put the Lower Manhattan, Midtown Manhattan, and Upper Manhattan main schemes into play. Place the glider counter on Midtown Manhattan. Flip this card and set it aside.",
 		"threat": null,
 		"type_code": "main_scheme"
@@ -1313,7 +1313,7 @@
 		"quantity": 1,
 		"set_code": "venom_goblin",
 		"set_position": 5,
-		"stage": null,
+		"stage": "B",
 		"text": "<b>Special</b>: Place 1 threat on each scheme. If a [[symbiote]] environment is in play, place 1 additional threat on this scheme.",
 		"threat": 11,
 		"type_code": "main_scheme"
@@ -1346,7 +1346,7 @@
 		"quantity": 1,
 		"set_code": "venom_goblin",
 		"set_position": 6,
-		"stage": null,
+		"stage": "C",
 		"text": "<b>Special</b>: Take 2 indirect damage. If a [[symbiote]] environment is in play, take 1 additional indirect damage.",
 		"threat": 12,
 		"type_code": "main_scheme"
@@ -1380,7 +1380,7 @@
 		"quantity": 1,
 		"set_code": "venom_goblin",
 		"set_position": 7,
-		"stage": null,
+		"stage": "D",
 		"text": "<b>Special</b>: Discard 1 card from your hand. If a [[symbiote]] environment is in play, discard the top 4 cards of your deck.",
 		"threat": 10,
 		"type_code": "main_scheme"

--- a/pack/toafk_encounter.json
+++ b/pack/toafk_encounter.json
@@ -16,8 +16,8 @@
 		"scheme": 1,
 		"set_code": "kang",
 		"set_position": 1,
-		"stage": 1,
-		"text": "Toughness\n[star] <b>Forced Interrupt:</b> When Kang attacks you, either place 1 threat on the main scheme, or he gets +2 ATK for this attack.\n<b>When Defeated:</b> Advance the main scheme to stage 2 at the end of the phase.",
+		"stage": "I",
+		"text": "Toughness\n[star] <b>Forced Interrupt</b>: When Kang attacks you, either place 1 threat on the main scheme, or he gets +2 ATK for this attack.\n<b>When Defeated</b>: Advance the main scheme to stage 2 at the end of the phase.",
 		"traits": "Temporal.",
 		"type_code": "villain"
 	},
@@ -36,8 +36,8 @@
 		"scheme": 2,
 		"set_code": "kang",
 		"set_position": 2,
-		"stage": 2,
-		"text": "Toughness.\nThis villain cannot take damage while a minion is in play.\n<b>When Defeated:</b> Remove the Chronopolis from the game. At the end of the phase, join another game area.",
+		"stage": "II",
+		"text": "Toughness.\nThis villain cannot take damage while a minion is in play.\n<b>When Defeated</b>: Remove the Chronopolis from the game. At the end of the phase, join another game area.",
 		"traits": "Temporal.",
 		"type_code": "villain"
 	},
@@ -56,8 +56,8 @@
 		"scheme": 1,
 		"set_code": "kang",
 		"set_position": 3,
-		"stage": 2,
-		"text": "Retaliate 1. Toughness.\n<b>When Defeated:</b> Remove Inexorable Fate from the game. At the end of the phase, join another game area.",
+		"stage": "II",
+		"text": "Retaliate 1. Toughness.\n<b>When Defeated</b>: Remove Inexorable Fate from the game. At the end of the phase, join another game area.",
 		"traits": "Temporal.",
 		"type_code": "villain"
 	},
@@ -77,8 +77,8 @@
 		"scheme": 1,
 		"set_code": "kang",
 		"set_position": 4,
-		"stage": 2,
-		"text": "Toughness.\n[star] This villain gets +1 ATK for each obligation in play.\n<b>When Defeated:</b> Remove the Realm of Rama-Tut from the game. At the end of the phase, join another game area.",
+		"stage": "II",
+		"text": "Toughness.\n[star] This villain gets +1 ATK for each obligation in play.\n<b>When Defeated</b>: Remove the Realm of Rama-Tut from the game. At the end of the phase, join another game area.",
 		"traits": "Temporal.",
 		"type_code": "villain"
 	},
@@ -98,8 +98,8 @@
 		"scheme": 0,
 		"set_code": "kang",
 		"set_position": 5,
-		"stage": 2,
-		"text": "Toughness.\n[star] This villain's attack gains piercing.\n<b>When Defeated:</b> Remove The Present Future War from the game. At the end of the phase, join another game area.",
+		"stage": "II",
+		"text": "Toughness.\n[star] This villain's attack gains piercing.\n<b>When Defeated</b>: Remove The Present Future War from the game. At the end of the phase, join another game area.",
 		"traits": "Temporal.",
 		"type_code": "villain"
 	},
@@ -120,8 +120,8 @@
 		"scheme": 2,
 		"set_code": "kang",
 		"set_position": 6,
-		"stage": 3,
-		"text": "Toughness.\n[star] <b>Forced Interrupt:</b> When Kang attacks you, either place 1 threat on the main scheme, or he gets +2 ATK for this attack.\n<b>When Defeated:</b> The players win the game.",
+		"stage": "III",
+		"text": "Toughness.\n[star] <b>Forced Interrupt</b>: When Kang attacks you, either place 1 threat on the main scheme, or he gets +2 ATK for this attack.\n<b>When Defeated</b>: The players win the game.",
 		"traits": "Temporal.",
 		"type_code": "villain"
 	},
@@ -137,8 +137,8 @@
 		"quantity": 1,
 		"set_code": "kang",
 		"set_position": 7,
-		"stage": 1,
-		"text": "<b>Contents:</b> Kang (I), each Kang (II), and Kang (III). Kang and Standard encounter sets. One modular encounter set <i>(Temporal).</i>\n<b>Setup:</b> Set each Kang (II), Kang (III), and Kang's Dominion side scheme aside. remove each player's obligation cards from the game. Shuffle the encounter deck.",
+		"stage": "1A",
+		"text": "<b>Contents</b>: Kang (I), each Kang (II), and Kang (III). Kang and Standard encounter sets. One modular encounter set <i>(Temporal).</i>\n<b>Setup</b>: Set each Kang (II), Kang (III), and Kang's Dominion side scheme aside. remove each player's obligation cards from the game. Shuffle the encounter deck.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -157,8 +157,8 @@
 		"quantity": 1,
 		"set_code": "kang",
 		"set_position": 7,
-		"stage": 1,
-		"text": "<b>When Revealed:</b> Deal each player an encounter card.\n<b>If this stage is completed, the players lose the game.</b>",
+		"stage": "1B",
+		"text": "<b>When Revealed</b>: Deal each player an encounter card.\n<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 7,
 		"type_code": "main_scheme"
 	},
@@ -175,8 +175,8 @@
 		"quantity": 1,
 		"set_code": "kang",
 		"set_position": 8,
-		"stage": 2,
-		"text": "<b>When Revealed:</b> Place 1 acceleration token here for each side scheme in play, then discard each side scheme. Each player reveals a random stage 3A in turn oder. Remove any unused stage 3 schemes from the game.",
+		"stage": "2A",
+		"text": "<b>When Revealed</b>: Place 1 acceleration token here for each side scheme in play, then discard each side scheme. Each player reveals a random stage 3A in turn oder. Remove any unused stage 3 schemes from the game.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -194,8 +194,8 @@
 		"quantity": 1,
 		"set_code": "kang",
 		"set_position": 8,
-		"stage": 2,
-		"text": "<b>Forced Interrupt:</b> When an acceleration token would be placed on another scheme, place it here instead.\n<b>Players cannot join this game area unless there are no other game areas remaining. When all the players have joined this game area, advanced to stage 4A.</b>",
+		"stage": "2B",
+		"text": "<b>Forced Interrupt</b>: When an acceleration token would be placed on another scheme, place it here instead.\n<b>Players cannot join this game area unless there are no other game areas remaining. When all the players have joined this game area, advanced to stage 4A.</b>",
 		"threat": null,
 		"threat_fixed": true,
 		"type_code": "main_scheme"
@@ -212,8 +212,8 @@
 		"quantity": 1,
 		"set_code": "kang",
 		"set_position": 9,
-		"stage": 3,
-		"text": "<b>When Revealed:</b> Create your own game area and place this scheme in it. Add Kang (Immortus) to the game area and deal yourself an encounter card.",
+		"stage": "3A",
+		"text": "<b>When Revealed</b>: Create your own game area and place this scheme in it. Add Kang (Immortus) to the game area and deal yourself an encounter card.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -232,8 +232,8 @@
 		"quantity": 1,
 		"set_code": "kang",
 		"set_position": 9,
-		"stage": 3,
-		"text": "<b>Forced Response:</b> After this stage is complete, place 1 set-aside Kang's Dominion facedown under stage 4A. At the end of the phase, remove Kang (Immortus) and this stage from the game and combine your game area with another game area.\n<b>If all the players at this stage are defeated, this stage is complete.</b>",
+		"stage": "3B",
+		"text": "<b>Forced Response</b>: After this stage is complete, place 1 set-aside Kang's Dominion facedown under stage 4A. At the end of the phase, remove Kang (Immortus) and this stage from the game and combine your game area with another game area.\n<b>If all the players at this stage are defeated, this stage is complete.</b>",
 		"threat": 9,
 		"threat_fixed": true,
 		"type_code": "main_scheme"
@@ -250,8 +250,8 @@
 		"quantity": 1,
 		"set_code": "kang",
 		"set_position": 10,
-		"stage": 3,
-		"text": "<b>When Revealed:</b> Create your own game area and place this scheme in it. Add Kang (Iron Lad) to the game area and deal yourself an encounter card.",
+		"stage": "3A",
+		"text": "<b>When Revealed</b>: Create your own game area and place this scheme in it. Add Kang (Iron Lad) to the game area and deal yourself an encounter card.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -270,8 +270,8 @@
 		"quantity": 1,
 		"set_code": "kang",
 		"set_position": 10,
-		"stage": 3,
-		"text": "<b>Forced Response:</b> After this stage is completed, place 1 set-aside Kang's Dominion facedown under stage 4A. At the end of the phase, remove Kang (Iron Lad) and this stage from the game and combine your game area with another game area.\n<b>If all the players at the stage are defeated, this stage is completed.</b>",
+		"stage": "3B",
+		"text": "<b>Forced Response</b>: After this stage is completed, place 1 set-aside Kang's Dominion facedown under stage 4A. At the end of the phase, remove Kang (Iron Lad) and this stage from the game and combine your game area with another game area.\n<b>If all the players at the stage are defeated, this stage is completed.</b>",
 		"threat": 9,
 		"threat_fixed": true,
 		"type_code": "main_scheme"
@@ -288,8 +288,8 @@
 		"quantity": 1,
 		"set_code": "kang",
 		"set_position": 11,
-		"stage": 3,
-		"text": "<b>When Revealed:</b> Create your own game area and place this scheme in it. Add Kang (Rama-Tut) to the game area and deal yourself an encounter card.",
+		"stage": "3A",
+		"text": "<b>When Revealed</b>: Create your own game area and place this scheme in it. Add Kang (Rama-Tut) to the game area and deal yourself an encounter card.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -308,8 +308,8 @@
 		"quantity": 1,
 		"set_code": "kang",
 		"set_position": 11,
-		"stage": 3,
-		"text": "<b>Forced Response:</b> After this stage is completed, place 1 set-aside Kang's Dominion facedown under stage 4A. At the end of the phase, remove Kang (Rama-Tut) and this stage from the game and combine your game area with another game area.\n<b>If all the players at this stage are defeated, this stage is completed.</b>",
+		"stage": "3B",
+		"text": "<b>Forced Response</b>: After this stage is completed, place 1 set-aside Kang's Dominion facedown under stage 4A. At the end of the phase, remove Kang (Rama-Tut) and this stage from the game and combine your game area with another game area.\n<b>If all the players at this stage are defeated, this stage is completed.</b>",
 		"threat": 9,
 		"threat_fixed": true,
 		"type_code": "main_scheme"
@@ -326,8 +326,8 @@
 		"quantity": 1,
 		"set_code": "kang",
 		"set_position": 12,
-		"stage": 3,
-		"text": "<b>When Revealed:</b> Create your own game area and place this scheme in it. Add Kang (Scarlet Centurion) to the game area and deal yourself an encounter card.",
+		"stage": "3A",
+		"text": "<b>When Revealed</b>: Create your own game area and place this scheme in it. Add Kang (Scarlet Centurion) to the game area and deal yourself an encounter card.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -346,8 +346,8 @@
 		"quantity": 1,
 		"set_code": "kang",
 		"set_position": 12,
-		"stage": 3,
-		"text": "<b>Forced Response:</b> After this stage is completed, place 1 set-aside Kang's Dominion facedown under stage 4A. At the end of the phase, remove Kang (Scarlet Centurion) and this stage from the game and combine your game area with another game area.\n<b>If all the players at this stage are defeated, this stage is completed.</b>",
+		"stage": "3B",
+		"text": "<b>Forced Response</b>: After this stage is completed, place 1 set-aside Kang's Dominion facedown under stage 4A. At the end of the phase, remove Kang (Scarlet Centurion) and this stage from the game and combine your game area with another game area.\n<b>If all the players at this stage are defeated, this stage is completed.</b>",
 		"threat": 9,
 		"threat_fixed": true,
 		"type_code": "main_scheme"
@@ -365,8 +365,8 @@
 		"quantity": 1,
 		"set_code": "kang",
 		"set_position": 13,
-		"stage": 4,
-		"text": "<b>When Revealed:</b> Reveal Kang (III) and add him to the game area. Reveal each face down Kang's Dominion under this stage.",
+		"stage": "4A",
+		"text": "<b>When Revealed</b>: Reveal Kang (III) and add him to the game area. Reveal each face down Kang's Dominion under this stage.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -384,8 +384,8 @@
 		"quantity": 1,
 		"set_code": "kang",
 		"set_position": 13,
-		"stage": 4,
-		"text": "<b>When Revealed:</b> Each player searches the encounter deck, discard pile, and set-aside area for their nemesis minion and puts it into play engaged with them. Shuffle the encounter deck.\n<b>If this stage is completed, the players lose the game.</b>",
+		"stage": "4B",
+		"text": "<b>When Revealed</b>: Each player searches the encounter deck, discard pile, and set-aside area for their nemesis minion and puts it into play engaged with them. Shuffle the encounter deck.\n<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 10,
 		"type_code": "main_scheme"
 	},
@@ -402,7 +402,7 @@
 		"quantity": 2,
 		"set_code": "kang",
 		"set_position": 14,
-		"text": "Attach to Kang.\n<b>Forced Interrupt:</b> When Kang is attacked, discard Temporal Shield → prevent all damage from this attack and deal 1 damage to the attacker. (Max 1 per attack.)",
+		"text": "Attach to Kang.\n<b>Forced Interrupt</b>: When Kang is attacked, discard Temporal Shield → prevent all damage from this attack and deal 1 damage to the attacker. (Max 1 per attack.)",
 		"traits": "Tech.",
 		"type_code": "attachment"
 	},
@@ -421,7 +421,7 @@
 		"quantity": 2,
 		"set_code": "kang",
 		"set_position": 16,
-		"text": "Attach to Kang.\n[star] <b>Forced Interrupt:</b> When Kang attacks, the attack gains overkill. If this attack damages a hero, that hero is stunned. After this attack, discard Future Weapon.",
+		"text": "Attach to Kang.\n[star] <b>Forced Interrupt</b>: When Kang attacks, the attack gains overkill. If this attack damages a hero, that hero is stunned. After this attack, discard Future Weapon.",
 		"traits": "Tech. Weapon.",
 		"type_code": "attachment"
 	},
@@ -437,7 +437,7 @@
 		"quantity": 1,
 		"set_code": "kang",
 		"set_position": 18,
-		"text": "Attach to your identity.\n<b>Forced Interrupt:</b> When attached character would ready, discard this card instead.\n<hr />\n[star] <b>Boost</b>: Attach to your identity.",
+		"text": "Attach to your identity.\n<b>Forced Interrupt</b>: When attached character would ready, discard this card instead.\n<hr />\n[star] <b>Boost</b>: Attach to your identity.",
 		"traits": "Temporal.",
 		"type_code": "attachment"
 	},
@@ -473,7 +473,7 @@
 		"quantity": 2,
 		"set_code": "kang",
 		"set_position": 22,
-		"text": "<b>Forced Response:</b> After you use a basic hero power, take 1 damage.\n<b>Alter-Ego Action:</b> Discard a [physical] resource from your hand → discard this obligation.",
+		"text": "<b>Forced Response</b>: After you use a basic hero power, take 1 damage.\n<b>Alter-Ego Action</b>: Discard a [physical] resource from your hand → discard this obligation.",
 		"traits": "Temporal.",
 		"type_code": "obligation"
 	},
@@ -489,7 +489,7 @@
 		"quantity": 2,
 		"set_code": "kang",
 		"set_position": 24,
-		"text": "<b>When Revealed:</b> Place the top 8 cards of your deck facedown under this card.\n<b>Alter-Ego Action:</b> Discard a [mental] resource from your hand → discard this obligation. <i>(Discard each facedown card under this obligation.)</i>",
+		"text": "<b>When Revealed</b>: Place the top 8 cards of your deck facedown under this card.\n<b>Alter-Ego Action</b>: Discard a [mental] resource from your hand → discard this obligation. <i>(Discard each facedown card under this obligation.)</i>",
 		"traits": "Temporal.",
 		"type_code": "obligation"
 	},
@@ -506,7 +506,7 @@
 		"quantity": 2,
 		"set_code": "kang",
 		"set_position": 26,
-		"text": "You cannot play hero-specific cards.\n<b>Alter-Ego Action:</b> Discard a hero-specific card from your hand → discard this obligation.",
+		"text": "You cannot play hero-specific cards.\n<b>Alter-Ego Action</b>: Discard a hero-specific card from your hand → discard this obligation.",
 		"traits": "Temporal.",
 		"type_code": "obligation"
 	},
@@ -522,7 +522,7 @@
 		"quantity": 2,
 		"set_code": "kang",
 		"set_position": 28,
-		"text": "<b>When Revealed:</b> Discard the highest-cost card you control, then place it facedown under this card.\n<b>Alter-Ego Action:</b> Discard a [energy] resource from your hand → discard this obligation.<i>(Discard each facedown card under this obligation.)</i>",
+		"text": "<b>When Revealed</b>: Discard the highest-cost card you control, then place it facedown under this card.\n<b>Alter-Ego Action</b>: Discard a [energy] resource from your hand → discard this obligation.<i>(Discard each facedown card under this obligation.)</i>",
 		"traits": "Temporal.",
 		"type_code": "obligation"
 	},
@@ -540,7 +540,7 @@
 		"quantity": 1,
 		"set_code": "kang",
 		"set_position": 30,
-		"text": "Players cannot trigger \"<b>Alter-Ego Action</b>\" abilities on obligations.\n<b>When Revealed:</b> Each player must either discard 1 random card from hand, or place 2 threat here.",
+		"text": "Players cannot trigger \"<b>Alter-Ego Action</b>\" abilities on obligations.\n<b>When Revealed</b>: Each player must either discard 1 random card from hand, or place 2 threat here.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -557,7 +557,7 @@
 		"quantity": 4,
 		"set_code": "kang",
 		"set_position": 31,
-		"text": "Kang cannot take damage.\n<b>When Defeated:</b> Deal the player who defeated this scheme an encounter card.",
+		"text": "Kang cannot take damage.\n<b>When Defeated</b>: Deal the player who defeated this scheme an encounter card.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -575,7 +575,7 @@
 		"scheme_crisis": 1,
 		"set_code": "kang",
 		"set_position": 35,
-		"text": "<b>When Revealed:</b> Place 2 threat here for each obligation in play.",
+		"text": "<b>When Revealed</b>: Place 2 threat here for each obligation in play.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -592,7 +592,7 @@
 		"scheme_acceleration": 1,
 		"set_code": "kang",
 		"set_position": 36,
-		"text": "<b>When Defeated:</b> Discard cards from the top of the encounter deck until a minion is discarded. Put that minion into play engaged with the player who defeated this scheme.",
+		"text": "<b>When Defeated</b>: Discard cards from the top of the encounter deck until a minion is discarded. Put that minion into play engaged with the player who defeated this scheme.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -607,7 +607,7 @@
 		"quantity": 2,
 		"set_code": "kang",
 		"set_position": 38,
-		"text": "<b>When Revealed (Alter-Ego):</b> Discard an ally or support you control. If you cannot, this card gains surge.\n<b>When Revealed (Hero):</b> Kang attacks you.",
+		"text": "<b>When Revealed (Alter-Ego)</b>: Discard an ally or support you control. If you cannot, this card gains surge.\n<b>When Revealed (Hero)</b>: Kang attacks you.",
 		"type_code": "treachery"
 	},
 	{
@@ -623,7 +623,7 @@
 		"quantity": 1,
 		"set_code": "kang",
 		"set_position": 40,
-		"text": "<b>When Revealed:</b> Discard each event from your hand. If no events are discarded this way, this card gains surge.",
+		"text": "<b>When Revealed</b>: Discard each event from your hand. If no events are discarded this way, this card gains surge.",
 		"type_code": "treachery"
 	},
 	{
@@ -639,7 +639,7 @@
 		"quantity": 2,
 		"set_code": "kang",
 		"set_position": 41,
-		"text": "Surge.\n<b>When Revealed:</b> Each player takes 1 indirect damage for each obligation in their play area.\n<hr />\n[star] <b>Boost</b>: This card gains [boost] for each obligation in your play area.",
+		"text": "Surge.\n<b>When Revealed</b>: Each player takes 1 indirect damage for each obligation in their play area.\n<hr />\n[star] <b>Boost</b>: This card gains [boost] for each obligation in your play area.",
 		"type_code": "treachery"
 	},
 	{
@@ -654,7 +654,7 @@
 		"quantity": 1,
 		"set_code": "kang",
 		"set_position": 43,
-		"text": "Incite 1. <i>(Place 1 threat on the main scheme when this card is revealed.)</i>\n<b>When Revealed:</b> Each player searches the encounter deck and discard pile for a different obligation and reveals it.\nShuffle the encounter deck.",
+		"text": "Incite 1. <i>(Place 1 threat on the main scheme when this card is revealed.)</i>\n<b>When Revealed</b>: Each player searches the encounter deck and discard pile for a different obligation and reveals it.\nShuffle the encounter deck.",
 		"type_code": "treachery"
 	},
 	{
@@ -692,7 +692,7 @@
 		"scheme": 1,
 		"set_code": "temporal",
 		"set_position": 4,
-		"text": "[star] <b>Forced Interrupt:</b> When Chitauri Soldier attacks you, discard the top card of the encounter deck → take indirect damage equal to the number of boost icons on that card.",
+		"text": "[star] <b>Forced Interrupt</b>: When Chitauri Soldier attacks you, discard the top card of the encounter deck → take indirect damage equal to the number of boost icons on that card.",
 		"traits": "Soldier. Temporal.",
 		"type_code": "minion"
 	},
@@ -730,7 +730,7 @@
 		"scheme_hazard": 1,
 		"set_code": "temporal",
 		"set_position": 7,
-		"text": "<b>Forced Interrupt:</b> When this scheme is defeated, shuffle it into the encounter deck instead of discarding it.",
+		"text": "<b>Forced Interrupt</b>: When this scheme is defeated, shuffle it into the encounter deck instead of discarding it.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -750,8 +750,8 @@
 		"scheme": 1,
 		"set_code": "exp_kang",
 		"set_position": 1,
-		"stage": 1,
-		"text": "Toughness.\n[star] <b>Forced Interrupt:</b> When Kang attacks you, either place 1 threat on the main scheme, or he gets +2 ATK for this attack.\n<b>When Defeated:</b> Advance the main scheme to stage 2 at the end of the phase.",
+		"stage": "I",
+		"text": "Toughness.\n[star] <b>Forced Interrupt</b>: When Kang attacks you, either place 1 threat on the main scheme, or he gets +2 ATK for this attack.\n<b>When Defeated</b>: Advance the main scheme to stage 2 at the end of the phase.",
 		"traits": "Temporal.",
 		"type_code": "villain"
 	},
@@ -770,8 +770,8 @@
 		"scheme": 3,
 		"set_code": "exp_kang",
 		"set_position": 2,
-		"stage": 2,
-		"text": "Toughness.\nThis villain cannot take damage while a minion is in play.\n<b>When Defeated:</b> Remove The Chronopolis from the game. At the end of the phase, join another game area.",
+		"stage": "II",
+		"text": "Toughness.\nThis villain cannot take damage while a minion is in play.\n<b>When Defeated</b>: Remove The Chronopolis from the game. At the end of the phase, join another game area.",
 		"traits": "Temporal.",
 		"type_code": "villain"
 	},
@@ -790,8 +790,8 @@
 		"scheme": 2,
 		"set_code": "exp_kang",
 		"set_position": 3,
-		"stage": 2,
-		"text": "Retaliate 1. Toughness.\n<b>When Defeated:</b> Remove Inexorable Fate from the game. At the end of the phase, join another game area.",
+		"stage": "II",
+		"text": "Retaliate 1. Toughness.\n<b>When Defeated</b>: Remove Inexorable Fate from the game. At the end of the phase, join another game area.",
 		"traits": "Temporal.",
 		"type_code": "villain"
 	},
@@ -811,8 +811,8 @@
 		"scheme": 2,
 		"set_code": "exp_kang",
 		"set_position": 4,
-		"stage": 2,
-		"text": "Toughness.\n[star] This villain gets +1 ATK for each obligation in play.\n<b>When Defeated:</b> Remove The Realm of Rama-Tut from the game. At the end of the phase, join another game area.",
+		"stage": "II",
+		"text": "Toughness.\n[star] This villain gets +1 ATK for each obligation in play.\n<b>When Defeated</b>: Remove The Realm of Rama-Tut from the game. At the end of the phase, join another game area.",
 		"traits": "Temporal.",
 		"type_code": "villain"
 	},
@@ -832,8 +832,8 @@
 		"scheme": 1,
 		"set_code": "exp_kang",
 		"set_position": 5,
-		"stage": 2,
-		"text": "Toughness.\n[star] This villain's attacks gain piercing.\n<b>When Defeated:</b> Remove The Present Future War from the game. At the end of the phase, join another game area.",
+		"stage": "II",
+		"text": "Toughness.\n[star] This villain's attacks gain piercing.\n<b>When Defeated</b>: Remove The Present Future War from the game. At the end of the phase, join another game area.",
 		"traits": "Temporal.",
 		"type_code": "villain"
 	},
@@ -854,8 +854,8 @@
 		"scheme": 3,
 		"set_code": "exp_kang",
 		"set_position": 6,
-		"stage": 3,
-		"text": "Toughness.\n[star] <b>Forced Interrupt:</b> When Kang attacks you, either place 1 threat on the main scheme, or he gets +2 ATK for this attack.\n<b>When Defeated:</b> The players win the game.",
+		"stage": "III",
+		"text": "Toughness.\n[star] <b>Forced Interrupt</b>: When Kang attacks you, either place 1 threat on the main scheme, or he gets +2 ATK for this attack.\n<b>When Defeated</b>: The players win the game.",
 		"traits": "Temporal.",
 		"type_code": "villain"
 	},
@@ -875,7 +875,7 @@
 		"scheme": 1,
 		"set_code": "anachronauts",
 		"set_position": 1,
-		"text": "<b>When Revealed:</b> Discard an ally or support you control.\n<hr />\n[star] <b>Boost</b>: Exhaust a character you control. Give this enemy another boost card.",
+		"text": "<b>When Revealed</b>: Discard an ally or support you control.\n<hr />\n[star] <b>Boost</b>: Exhaust a character you control. Give this enemy another boost card.",
 		"traits": "Elite. Temporal.",
 		"type_code": "minion"
 	},
@@ -956,7 +956,7 @@
 		"scheme": 1,
 		"set_code": "anachronauts",
 		"set_position": 5,
-		"text": "<b>When Revealed:</b> Discard 1 random card from your hand.\n<hr />\n[star] <b>Boost</b>: Discard 1 random card from your hand. Give this enemy another boost card.",
+		"text": "<b>When Revealed</b>: Discard 1 random card from your hand.\n<hr />\n[star] <b>Boost</b>: Discard 1 random card from your hand. Give this enemy another boost card.",
 		"traits": "Elite. Temporal.",
 		"type_code": "minion"
 	},
@@ -974,7 +974,7 @@
 		"scheme_hazard": 1,
 		"set_code": "anachronauts",
 		"set_position": 6,
-		"text": "<b>When Defeated:</b> Shuffle each [[Temporal]] card in the encounter discard pile into the encounter deck.",
+		"text": "<b>When Defeated</b>: Shuffle each [[Temporal]] card in the encounter discard pile into the encounter deck.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -988,7 +988,7 @@
 		"quantity": 2,
 		"set_code": "anachronauts",
 		"set_position": 8,
-		"text": "Incite 1. <i>(When revealed, place 1 threat on the main scheme.)</i>\n<b>When Revealed:</b> Discard cards from the top of the encounter deck until a [[Temporal]] minion is discarded. Reveal that minion.",
+		"text": "Incite 1. <i>(When revealed, place 1 threat on the main scheme.)</i>\n<b>When Revealed</b>: Discard cards from the top of the encounter deck until a [[Temporal]] minion is discarded. Reveal that minion.",
 		"type_code": "treachery"
 	},
 	{
@@ -1042,7 +1042,7 @@
 		"quantity": 2,
 		"set_code": "mot",
 		"set_position": 4,
-		"text": "You cannot attack Kang.\n<b>Alter-Ego Action:</b> Discard a random card from your hand → discard this obligation.",
+		"text": "You cannot attack Kang.\n<b>Alter-Ego Action</b>: Discard a random card from your hand → discard this obligation.",
 		"traits": "Temporal.",
 		"type_code": "obligation"
 	},
@@ -1060,7 +1060,7 @@
 		"scheme_hazard": 1,
 		"set_code": "mot",
 		"set_position": 6,
-		"text": "<b>When Defeated:</b> Discard cards from the top of the encounter deck until a minion is discarded. Put that minion into play engaged with the player who defeated this scheme.",
+		"text": "<b>When Defeated</b>: Discard cards from the top of the encounter deck until a minion is discarded. Put that minion into play engaged with the player who defeated this scheme.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1075,7 +1075,7 @@
 		"quantity": 2,
 		"set_code": "mot",
 		"set_position": 7,
-		"text": "<b>When Revealed:</b> Kang (Master of Time) activates against you. If Kang (Master of Time) is not in play, search the encounter deck and discard pile for Kang (Master of Time) and put him into play engaged with you. Shuffle the encounter deck.",
+		"text": "<b>When Revealed</b>: Kang (Master of Time) activates against you. If Kang (Master of Time) is not in play, search the encounter deck and discard pile for Kang (Master of Time) and put him into play engaged with you. Shuffle the encounter deck.",
 		"type_code": "treachery"
 	}
 ]

--- a/pack/trors_encounter.json
+++ b/pack/trors_encounter.json
@@ -49,7 +49,7 @@
 		"scheme_acceleration": 1,
 		"set_code": "hawkeye_nemesis",
 		"set_position": 2,
-		"text": "<b>When Revealed:</b> The Clint Barton player searches their hand, deck, discard pile, and play area for Mockingbird and places her faceup beneath this card. When this scheme is defeated, return Mockingbird to her owner's hand.",
+		"text": "<b>When Revealed</b>: The Clint Barton player searches their hand, deck, discard pile, and play area for Mockingbird and places her faceup beneath this card. When this scheme is defeated, return Mockingbird to her owner's hand.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -67,7 +67,7 @@
 		"quantity": 1,
 		"set_code": "hawkeye_nemesis",
 		"set_position": 3,
-		"text": "Attach to Crossfire. Otherwise, attach to the villain.\n[star] When attached enemy attacks, the attack gains ranged.\n<b>Hero Action:</b> Exhaust your hero and spend a [wild] resource → discard Crossfire's Rifle.",
+		"text": "Attach to Crossfire. Otherwise, attach to the villain.\n[star] When attached enemy attacks, the attack gains ranged.\n<b>Hero Action</b>: Exhaust your hero and spend a [wild] resource → discard Crossfire's Rifle.",
 		"traits": "Weapon.",
 		"type_code": "attachment"
 	},
@@ -83,7 +83,7 @@
 		"quantity": 2,
 		"set_code": "hawkeye_nemesis",
 		"set_position": 4,
-		"text": "<b>When Revealed (Alter-Ego):</b> Place 3 threat on the main scheme.\n<b>When Revealed (Hero):</b> Deal 3 damage to your hero.",
+		"text": "<b>When Revealed (Alter-Ego)</b>: Place 3 threat on the main scheme.\n<b>When Revealed (Hero)</b>: Deal 3 damage to your hero.",
 		"type_code": "treachery"
 	},
 	{
@@ -135,7 +135,7 @@
 		"scheme_hazard": 1,
 		"set_code": "spider_woman_nemesis",
 		"set_position": 2,
-		"text": "<b>When Revealed:</b> Place an additional 1[per_hero] threat here.",
+		"text": "<b>When Revealed</b>: Place an additional 1[per_hero] threat here.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -170,7 +170,7 @@
 		"quantity": 1,
 		"set_code": "spider_woman_nemesis",
 		"set_position": 5,
-		"text": "<b>When Revealed:</b> Each [[Hydra]] minion engaged with a hero attacks that hero. Each player who was not attacked this way searches the encounter deck and discard pile for a [[Hydra]] minion and puts it into play engaged with them. Shuffle the encounter deck if it was searched.",
+		"text": "<b>When Revealed</b>: Each [[Hydra]] minion engaged with a hero attacks that hero. Each player who was not attacked this way searches the encounter deck and discard pile for a [[Hydra]] minion and puts it into play engaged with them. Shuffle the encounter deck if it was searched.",
 		"type_code": "treachery"
 	},
 	{
@@ -191,7 +191,7 @@
 		"scheme": 1,
 		"set_code": "crossbones",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "[star] While Crossbones has a [[Weapon]] attachment, his attacks gain piercing. <i>(Discard any tough status cards from the target before dealing damage.)</i>",
 		"traits": "Hydra. Mercenary.",
 		"type_code": "villain"
@@ -213,7 +213,7 @@
 		"scheme": 2,
 		"set_code": "crossbones",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "II",
 		"text": "[star] While Crossbones has a [[Weapon]] attachment, his attacks gain piercing.\n<b>When Revealed</b>: Search the encounter deck and discard pile for Crossbone's Machine Gun and attach it to Crossbones. Shuffle the encounter deck.",
 		"traits": "Hydra. Mercenary.",
 		"type_code": "villain"
@@ -236,7 +236,7 @@
 		"scheme": 2,
 		"set_code": "crossbones",
 		"set_position": 3,
-		"stage": 3,
+		"stage": "III",
 		"text": "[star] While Crossbones has a [[Weapon]] attachment, his attacks gain piercing.\n<b>When Revealed</b>: Reveal the top card of the Experimental Weapons deck.",
 		"traits": "Hydra. Mercenary.",
 		"type_code": "villain"
@@ -254,8 +254,8 @@
 		"quantity": 1,
 		"set_code": "crossbones",
 		"set_position": 4,
-		"stage": 1,
-		"text": "<b>Contents:</b> Crossbones (I) and Crossbones (II). Crossbones, Experimental Weapons, and Standard Encounter sets. Three modular sets <i>(Hydra Assault, Weapon Master, and Legions of Hydra).</i>\n<b>Setup:</b> Create the Experimental Weapons deck and set it next to the main scheme deck. <i>(see rulebook page 5.)</i>",
+		"stage": "1A",
+		"text": "<b>Contents</b>: Crossbones (I) and Crossbones (II). Crossbones, Experimental Weapons, and Standard Encounter sets. Three modular sets <i>(Hydra Assault, Weapon Master, and Legions of Hydra).</i>\n<b>Setup</b>: Create the Experimental Weapons deck and set it next to the main scheme deck. <i>(see rulebook page 5.)</i>",
 		"type_code": "main_scheme"
 	},
 	{
@@ -274,7 +274,7 @@
 		"quantity": 1,
 		"set_code": "crossbones",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1B",
 		"threat": 3,
 		"type_code": "main_scheme"
 	},
@@ -291,7 +291,7 @@
 		"quantity": 1,
 		"set_code": "crossbones",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2A",
 		"type_code": "main_scheme"
 	},
 	{
@@ -308,8 +308,8 @@
 		"quantity": 1,
 		"set_code": "crossbones",
 		"set_position": 5,
-		"stage": 2,
-		"text": "<b>When Revealed:</b> Reveal the top card of the Experimental Weapons deck.",
+		"stage": "2B",
+		"text": "<b>When Revealed</b>: Reveal the top card of the Experimental Weapons deck.",
 		"threat": 6,
 		"type_code": "main_scheme"
 	},
@@ -326,7 +326,7 @@
 		"quantity": 1,
 		"set_code": "crossbones",
 		"set_position": 6,
-		"stage": 3,
+		"stage": "3A",
 		"type_code": "main_scheme"
 	},
 	{
@@ -343,8 +343,8 @@
 		"quantity": 1,
 		"set_code": "crossbones",
 		"set_position": 6,
-		"stage": 3,
-		"text": "<b>When Revealed:</b> Reveal the top card of the Experimental Weapons deck.\n<b>If this stage is completed, the players lose the game.</b>",
+		"stage": "3B",
+		"text": "<b>When Revealed</b>: Reveal the top card of the Experimental Weapons deck.\n<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 5,
 		"type_code": "main_scheme"
 	},
@@ -383,7 +383,7 @@
 		"scheme": 1,
 		"set_code": "crossbones",
 		"set_position": 8,
-		"text": "Attach to Crossbones.\n<b>Forced Interrupt:</b> When Crossbones would take any amount of damage, place it here instead. If there is 5 or more damage here, discard Crossbones' Armor.",
+		"text": "Attach to Crossbones.\n<b>Forced Interrupt</b>: When Crossbones would take any amount of damage, place it here instead. If there is 5 or more damage here, discard Crossbones' Armor.",
 		"traits": "Armor.",
 		"type_code": "attachment"
 	},
@@ -402,7 +402,7 @@
 		"scheme": 1,
 		"set_code": "crossbones",
 		"set_position": 9,
-		"text": "<b>When Revealed:</b> Choose to either take 2 damage or place 1 threat on the main scheme.",
+		"text": "<b>When Revealed</b>: Choose to either take 2 damage or place 1 threat on the main scheme.",
 		"traits": "Hydra.",
 		"type_code": "minion"
 	},
@@ -418,7 +418,7 @@
 		"quantity": 2,
 		"set_code": "crossbones",
 		"set_position": 11,
-		"text": "<b>When Revealed (Alter-Ego):</b> Surge.\n<b>When Revealed (Hero):</b> Discard X cards from the top of the encounter deck, where X is Crossbones' ATK. Take 1 indirect damage for each boost icon discarded this way.",
+		"text": "<b>When Revealed (Alter-Ego)</b>: Surge.\n<b>When Revealed (Hero)</b>: Discard X cards from the top of the encounter deck, where X is Crossbones' ATK. Take 1 indirect damage for each boost icon discarded this way.",
 		"type_code": "treachery"
 	},
 	{
@@ -433,7 +433,7 @@
 		"quantity": 2,
 		"set_code": "crossbones",
 		"set_position": 13,
-		"text": "<b>When Revealed:</b> Give the villain a tough status card. If you cannot, heal 3 damage from it instead.\n<hr />\n[star] <b>Boost</b>: Give the villain a tough status card. If you cannot, heal 3 damage from it instead.",
+		"text": "<b>When Revealed</b>: Give the villain a tough status card. If you cannot, heal 3 damage from it instead.\n<hr />\n[star] <b>Boost</b>: Give the villain a tough status card. If you cannot, heal 3 damage from it instead.",
 		"type_code": "treachery"
 	},
 	{
@@ -448,7 +448,7 @@
 		"quantity": 2,
 		"set_code": "crossbones",
 		"set_position": 15,
-		"text": "Incite 1. <i>(When this card is revealed place 1 threat on the main scheme.)</i>\n<b>When Revealed:</b> Discard cards from the top of the encounter deck until a [[Weapon]] attachment is discarded. Reveal that card.",
+		"text": "Incite 1. <i>(When this card is revealed place 1 threat on the main scheme.)</i>\n<b>When Revealed</b>: Discard cards from the top of the encounter deck until a [[Weapon]] attachment is discarded. Reveal that card.",
 		"type_code": "treachery"
 	},
 	{
@@ -466,7 +466,7 @@
 		"scheme_acceleration": 1,
 		"set_code": "crossbones",
 		"set_position": 17,
-		"text": "<b>When Defeated:</b> Crossbones activates against the player who defeated this scheme.",
+		"text": "<b>When Defeated</b>: Crossbones activates against the player who defeated this scheme.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -485,7 +485,7 @@
 		"scheme_crisis": 1,
 		"set_code": "crossbones",
 		"set_position": 19,
-		"text": "<b>When Revealed:</b> Discard 1[per_hero] cards from the top of the encounter deck. Place 1 additional threat here for each boost icon discarded this way.",
+		"text": "<b>When Revealed</b>: Discard 1[per_hero] cards from the top of the encounter deck. Place 1 additional threat here for each boost icon discarded this way.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -502,7 +502,7 @@
 		"quantity": 1,
 		"set_code": "exper_weapon",
 		"set_position": 1,
-		"text": "Attach to the Villain.\n[star] <b>Forced Interrupt:</b> When attached villain attacks, the attack gains ranged.\n<b>Hero Action:</b> Spend [energy][physical] resources → discard this card.",
+		"text": "Attach to the Villain.\n[star] <b>Forced Interrupt</b>: When attached villain attacks, the attack gains ranged.\n<b>Hero Action</b>: Spend [energy][physical] resources → discard this card.",
 		"traits": "Experimental. Weapon.",
 		"type_code": "attachment"
 	},
@@ -519,7 +519,7 @@
 		"quantity": 1,
 		"set_code": "exper_weapon",
 		"set_position": 2,
-		"text": "Attach to the villain.\nAttached villain gains retaliate 1.\n<b>Hero Action:</b> Spend [energy][mental] resources → discard this card.",
+		"text": "Attach to the villain.\nAttached villain gains retaliate 1.\n<b>Hero Action</b>: Spend [energy][mental] resources → discard this card.",
 		"traits": "Experimental. Weapon.",
 		"type_code": "attachment"
 	},
@@ -537,7 +537,7 @@
 		"quantity": 1,
 		"set_code": "exper_weapon",
 		"set_position": 3,
-		"text": "Attach to the Villain.\n[star] <b>Forced Response:</b> After the attached villain attacks and damages you, discard 1 card from your hand.\n<b>Hero Action:</b> Spend [mental][physical] resources → discard this card.",
+		"text": "Attach to the Villain.\n[star] <b>Forced Response</b>: After the attached villain attacks and damages you, discard 1 card from your hand.\n<b>Hero Action</b>: Spend [mental][physical] resources → discard this card.",
 		"traits": "Experimental. Weapon.",
 		"type_code": "attachment"
 	},
@@ -556,7 +556,7 @@
 		"scheme": 1,
 		"set_code": "exper_weapon",
 		"set_position": 4,
-		"text": "Attach to the villain.\n<b>Hero Action:</b> Spend [energy][mental][physical] resources → discard this card.",
+		"text": "Attach to the villain.\n<b>Hero Action</b>: Spend [energy][mental][physical] resources → discard this card.",
 		"traits": "Experimental. Weapon.",
 		"type_code": "attachment"
 	},
@@ -577,7 +577,7 @@
 		"scheme": 1,
 		"set_code": "absorbing_man",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "Absorbing Man gains the trait of each environment in play.",
 		"traits": "Brute.",
 		"type_code": "villain"
@@ -598,8 +598,8 @@
 		"scheme": 2,
 		"set_code": "absorbing_man",
 		"set_position": 2,
-		"stage": 2,
-		"text": "Absorbing Man gains the trait of each environment in play.\n<b>When Revealed:</b> If Super Absorbing Power is in play, deal 1 encounter card to each player. Otherwise, search the encounter deck and discard pile for Super Absorbing Power and reveal it. Shuffle the encounter deck if it was searched this way.",
+		"stage": "II",
+		"text": "Absorbing Man gains the trait of each environment in play.\n<b>When Revealed</b>: If Super Absorbing Power is in play, deal 1 encounter card to each player. Otherwise, search the encounter deck and discard pile for Super Absorbing Power and reveal it. Shuffle the encounter deck if it was searched this way.",
 		"traits": "Brute.",
 		"type_code": "villain"
 	},
@@ -621,7 +621,7 @@
 		"scheme_star": true,
 		"set_code": "absorbing_man",
 		"set_position": 3,
-		"stage": 3,
+		"stage": "III",
 		"text": "Absorbing Man gains the trait of each environment in play.\n[star] <b>Forced Response</b>: After Absorbing Man activates against you, if he has the:\n\u2022 [[Ice]] or [[Stone]] trait, place 1 threat on the main scheme.\n\u2022 [[Metal]] or [[Wood]] trait, take 1 indirect damage.",
 		"traits": "Brute.",
 		"type_code": "villain"
@@ -638,8 +638,8 @@
 		"quantity": 1,
 		"set_code": "absorbing_man",
 		"set_position": 4,
-		"stage": 1,
-		"text": "<b>Contents:</b> Absorbing Man (I) and Absorbing Man (II). Absorbing Man and Standard encounter sets. One modular encounter set <i>(Hydra Patrol).</i>\n<b>Setup:</b> Discard cards from the encounter deck until an environment is discarded. Put that card into play and shuffle the encounter discard pile into the encounter deck.",
+		"stage": "1A",
+		"text": "<b>Contents</b>: Absorbing Man (I) and Absorbing Man (II). Absorbing Man and Standard encounter sets. One modular encounter set <i>(Hydra Patrol).</i>\n<b>Setup</b>: Discard cards from the encounter deck until an environment is discarded. Put that card into play and shuffle the encounter discard pile into the encounter deck.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -657,7 +657,7 @@
 		"quantity": 1,
 		"set_code": "absorbing_man",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1B",
 		"text": "[star] <b>Forced Response</b>: After resolving step one of the villain phase, place 1 delay counter here.\n<b>Forced Interrupt</b>: When an environment enters play, discard each other environment card in play.\n<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 12,
 		"type_code": "main_scheme"
@@ -674,7 +674,7 @@
 		"quantity": 1,
 		"set_code": "absorbing_man",
 		"set_position": 5,
-		"text": "Surge.\n<b>Forced Response:</b> After Absorbing Man makes an undefended attack against you, take 1 indirect damage (2 indirect damage instead if there are 5 or more delay counters on the main scheme).\n<hr />\n[star] <b>Boost</b>: Put this card into play.",
+		"text": "Surge.\n<b>Forced Response</b>: After Absorbing Man makes an undefended attack against you, take 1 indirect damage (2 indirect damage instead if there are 5 or more delay counters on the main scheme).\n<hr />\n[star] <b>Boost</b>: Put this card into play.",
 		"traits": "Wood.",
 		"type_code": "environment"
 	},
@@ -690,7 +690,7 @@
 		"quantity": 1,
 		"set_code": "absorbing_man",
 		"set_position": 6,
-		"text": "Surge.\n<b>Forced Response:</b> After Absorbing Man makes an undefended attack against you, place 1 threat on the main scheme (2 threat instead if there are 5 or more delay counters on the main scheme).\n<hr />\n[star] <b>Boost</b>: Put this card into play.",
+		"text": "Surge.\n<b>Forced Response</b>: After Absorbing Man makes an undefended attack against you, place 1 threat on the main scheme (2 threat instead if there are 5 or more delay counters on the main scheme).\n<hr />\n[star] <b>Boost</b>: Put this card into play.",
 		"traits": "Ice.",
 		"type_code": "environment"
 	},
@@ -706,7 +706,7 @@
 		"quantity": 1,
 		"set_code": "absorbing_man",
 		"set_position": 7,
-		"text": "Surge.\n<b>Forced Response:</b> After Absorbing Man makes an undefended attack against you, heal 1 damage from him (2 damage instead if there are 5 or more delay counters on the main scheme).\n<hr />\n[star] <b>Boost</b>: Put this card into play.",
+		"text": "Surge.\n<b>Forced Response</b>: After Absorbing Man makes an undefended attack against you, heal 1 damage from him (2 damage instead if there are 5 or more delay counters on the main scheme).\n<hr />\n[star] <b>Boost</b>: Put this card into play.",
 		"traits": "Stone.",
 		"type_code": "environment"
 	},
@@ -722,7 +722,7 @@
 		"quantity": 1,
 		"set_code": "absorbing_man",
 		"set_position": 8,
-		"text": "Surge.\n<b>Forced Response:</b> After Absorbing Man makes an undefended attack against you, discard 1 resource icon from your hand (2 resources instead if there are 5 or more delay counters on the main scheme).\n<hr />\n[star] <b>Boost</b>: Put this card into play.",
+		"text": "Surge.\n<b>Forced Response</b>: After Absorbing Man makes an undefended attack against you, discard 1 resource icon from your hand (2 resources instead if there are 5 or more delay counters on the main scheme).\n<hr />\n[star] <b>Boost</b>: Put this card into play.",
 		"traits": "Metal.",
 		"type_code": "environment"
 	},
@@ -741,7 +741,7 @@
 		"scheme": 1,
 		"set_code": "absorbing_man",
 		"set_position": 9,
-		"text": "Attach to Absorbing Man.\n<b>Hero Action:</b> Spend a [physical] resource → shuffle this card into the encounter deck.\n<hr />\n[star] <b>Boost</b>: Reveal this card.",
+		"text": "Attach to Absorbing Man.\n<b>Hero Action</b>: Spend a [physical] resource → shuffle this card into the encounter deck.\n<hr />\n[star] <b>Boost</b>: Reveal this card.",
 		"traits": "Weapon.",
 		"type_code": "attachment"
 	},
@@ -757,7 +757,7 @@
 		"quantity": 2,
 		"set_code": "absorbing_man",
 		"set_position": 10,
-		"text": "<b>When Revealed:</b> Place 1 threat on the main scheme for every 2 delay counters on the main scheme. If no threat was placed this way, this card gains surge.\n<hr />\n[star] <b>Boost</b>: If there are 5 or more delay counters on the main scheme, take 1 indirect damage.",
+		"text": "<b>When Revealed</b>: Place 1 threat on the main scheme for every 2 delay counters on the main scheme. If no threat was placed this way, this card gains surge.\n<hr />\n[star] <b>Boost</b>: If there are 5 or more delay counters on the main scheme, take 1 indirect damage.",
 		"type_code": "treachery"
 	},
 	{
@@ -772,7 +772,7 @@
 		"quantity": 2,
 		"set_code": "absorbing_man",
 		"set_position": 12,
-		"text": "<b>When Revealed (Alter-Ego):</b> Absorbing Man schemes. If Absorbing Man has the [[Stone]] trait, he gets +1 SCH for this activation.\n<b>When Revealed (Hero):</b> Absorbing Man attacks you. If Absorbing Man has the [[Stone]] trait, he gets +1 ATK for this activation.",
+		"text": "<b>When Revealed (Alter-Ego)</b>: Absorbing Man schemes. If Absorbing Man has the [[Stone]] trait, he gets +1 SCH for this activation.\n<b>When Revealed (Hero)</b>: Absorbing Man attacks you. If Absorbing Man has the [[Stone]] trait, he gets +1 ATK for this activation.",
 		"type_code": "treachery"
 	},
 	{
@@ -787,7 +787,7 @@
 		"quantity": 2,
 		"set_code": "absorbing_man",
 		"set_position": 14,
-		"text": "<b>When Revealed (Alter-Ego):</b> Place 2 threat on the main scheme (3 threat instead if Absorbing Man has the [[Metal]] trait.)\n<b>When Revealed (Hero):</b> Take 3 indirect damage (4 indirect damage instead if Absorbing Man has the [[Metal]] trait.)",
+		"text": "<b>When Revealed (Alter-Ego)</b>: Place 2 threat on the main scheme (3 threat instead if Absorbing Man has the [[Metal]] trait.)\n<b>When Revealed (Hero)</b>: Take 3 indirect damage (4 indirect damage instead if Absorbing Man has the [[Metal]] trait.)",
 		"type_code": "treachery"
 	},
 	{
@@ -803,7 +803,7 @@
 		"quantity": 2,
 		"set_code": "absorbing_man",
 		"set_position": 16,
-		"text": "<b>When Revealed:</b> Discard 1 card at random from your hand. If Absorbing Man has the [[Wood]] trait, discard 1 card you control.\n<hr />\n[star] <b>Boost</b>: If Absorbing Man has the [[Stone]] or [[Wood]] trait, you are stunned.",
+		"text": "<b>When Revealed</b>: Discard 1 card at random from your hand. If Absorbing Man has the [[Wood]] trait, discard 1 card you control.\n<hr />\n[star] <b>Boost</b>: If Absorbing Man has the [[Stone]] or [[Wood]] trait, you are stunned.",
 		"type_code": "treachery"
 	},
 	{
@@ -818,7 +818,7 @@
 		"quantity": 3,
 		"set_code": "absorbing_man",
 		"set_position": 18,
-		"text": "<b>When Revealed:</b> If Absorbing Man has the:\n- [[Ice]] trait, exhaust your identity.\n- [[Metal]] trait, give Absorbing Man a tough status card and heal 1 damage from him.\n- [[Stone]] trait, give Absorbing Man 1 facedown boost card.\n- [[Wood]] trait, discard 1 card at random from your hand.",
+		"text": "<b>When Revealed</b>: If Absorbing Man has the:\n- [[Ice]] trait, exhaust your identity.\n- [[Metal]] trait, give Absorbing Man a tough status card and heal 1 damage from him.\n- [[Stone]] trait, give Absorbing Man 1 facedown boost card.\n- [[Wood]] trait, discard 1 card at random from your hand.",
 		"type_code": "treachery"
 	},
 	{
@@ -834,7 +834,7 @@
 		"quantity": 2,
 		"set_code": "absorbing_man",
 		"set_position": 21,
-		"text": "<b>When Revealed:</b> You are stunned. If Absorbing Man has the [[Ice]] trait, take 2 indirect damage.\n<hr />\n[star] <b>Boost</b>: If Absorbing Man has the [[Ice]] or [[Metal]] trait, give him a tough status card.",
+		"text": "<b>When Revealed</b>: You are stunned. If Absorbing Man has the [[Ice]] trait, take 2 indirect damage.\n<hr />\n[star] <b>Boost</b>: If Absorbing Man has the [[Ice]] or [[Metal]] trait, give him a tough status card.",
 		"type_code": "treachery"
 	},
 	{
@@ -851,7 +851,7 @@
 		"scheme_acceleration": 1,
 		"set_code": "absorbing_man",
 		"set_position": 23,
-		"text": "<b>When Revealed:</b> Each Player must choose to either spend a [energy] resource or take 2 indirect damage (3 indirect damage instead if there are 5 or more delay counters on the main scheme.)",
+		"text": "<b>When Revealed</b>: Each Player must choose to either spend a [energy] resource or take 2 indirect damage (3 indirect damage instead if there are 5 or more delay counters on the main scheme.)",
 		"type_code": "side_scheme"
 	},
 	{
@@ -887,8 +887,8 @@
 		"scheme": 1,
 		"set_code": "taskmaster",
 		"set_position": 1,
-		"stage": 1,
-		"text": "<b>Forced Response:</b> After a player changes to hero form, they discard the top card of the encounter deck and take damage equal to the number of boost icons on that card.",
+		"stage": "I",
+		"text": "<b>Forced Response</b>: After a player changes to hero form, they discard the top card of the encounter deck and take damage equal to the number of boost icons on that card.",
 		"traits": "Hydra. Mercenary.",
 		"type_code": "villain"
 	},
@@ -907,8 +907,8 @@
 		"scheme": 2,
 		"set_code": "taskmaster",
 		"set_position": 2,
-		"stage": 2,
-		"text": "<b>When Revealed:</b> Deal each player an encounter card.\n<b>Forced Response:</b> After a player changes to hero form, they discard the top card of the encounter deck and take damage equal to the number of boost icons on that card.",
+		"stage": "II",
+		"text": "<b>When Revealed</b>: Deal each player an encounter card.\n<b>Forced Response</b>: After a player changes to hero form, they discard the top card of the encounter deck and take damage equal to the number of boost icons on that card.",
 		"traits": "Hydra. Mercenary.",
 		"type_code": "villain"
 	},
@@ -927,8 +927,8 @@
 		"scheme": 3,
 		"set_code": "taskmaster",
 		"set_position": 3,
-		"stage": 3,
-		"text": "<b>When Revealed:</b> Deal each player an encounter card.\n<b>Forced Response:</b> After a player changes to hero form, they discard the top card of the encounter deck and take damage equal to the number of boost icons on that card.",
+		"stage": "III",
+		"text": "<b>When Revealed</b>: Deal each player an encounter card.\n<b>Forced Response</b>: After a player changes to hero form, they discard the top card of the encounter deck and take damage equal to the number of boost icons on that card.",
 		"traits": "Hydra. Mercenary.",
 		"type_code": "villain"
 	},
@@ -944,8 +944,8 @@
 		"quantity": 1,
 		"set_code": "taskmaster",
 		"set_position": 4,
-		"stage": 1,
-		"text": "<b>Contents:</b> Taskmaster (I) and Taskmaster (II). Taskmaster, Hydra Patrol, and Standard encounter sets. One modular encounter set <i>(Weapon Master).</i>\n<b>Setup:</b> Set each [[Captive]] ally aside out of play. Search the encounter deck for Hydra Patrol and put it into play. Shuffle the encounter deck.",
+		"stage": "1A",
+		"text": "<b>Contents</b>: Taskmaster (I) and Taskmaster (II). Taskmaster, Hydra Patrol, and Standard encounter sets. One modular encounter set <i>(Weapon Master).</i>\n<b>Setup</b>: Set each [[Captive]] ally aside out of play. Search the encounter deck for Hydra Patrol and put it into play. Shuffle the encounter deck.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -964,7 +964,7 @@
 		"quantity": 1,
 		"set_code": "taskmaster",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1B",
 		"text": "[star] <b>Forced Response</b>: After resolving step one of the villain phase, each player in hero form must choose to either place 1 threat here or take 1 damage.\n<b>If this stage is completed, the players lose the game.</b>",
 		"threat": 12,
 		"type_code": "main_scheme"
@@ -987,7 +987,7 @@
 		"set_code": "taskmaster",
 		"set_position": 5,
 		"subname": "Marc Spector",
-		"text": "<b>Response:</b> After you play Moon Knight from your hand, spend a [wild] resource → draw 2 cards.",
+		"text": "<b>Response</b>: After you play Moon Knight from your hand, spend a [wild] resource → draw 2 cards.",
 		"thwart": 2,
 		"thwart_cost": 1,
 		"traits": "Captive. Hero for Hire.",
@@ -1011,7 +1011,7 @@
 		"resource_wild": 1,
 		"set_code": "taskmaster",
 		"set_position": 6,
-		"text": "<b>Response:</b> After you play Shang-Chi from your hand, spend a [energy] resource → stun an enemy.",
+		"text": "<b>Response</b>: After you play Shang-Chi from your hand, spend a [energy] resource → stun an enemy.",
 		"thwart": 2,
 		"thwart_cost": 1,
 		"traits": "Captive. Hero for Hire.",
@@ -1035,7 +1035,7 @@
 		"set_code": "taskmaster",
 		"set_position": 7,
 		"subname": "Angela Del Toro",
-		"text": "<b>Response:</b> After you play White Tiger from your hand, spend [mental] resource → remove 3 threat from a scheme.",
+		"text": "<b>Response</b>: After you play White Tiger from your hand, spend [mental] resource → remove 3 threat from a scheme.",
 		"thwart": 3,
 		"thwart_cost": 1,
 		"traits": "Captive. Hero for Hire.",
@@ -1058,7 +1058,7 @@
 		"resource_wild": 1,
 		"set_code": "taskmaster",
 		"set_position": 8,
-		"text": "<b>Response:</b> After you play Elektra from your hand, spend a [physical] resource → deal 3 damage to an enemy.",
+		"text": "<b>Response</b>: After you play Elektra from your hand, spend a [physical] resource → deal 3 damage to an enemy.",
 		"thwart": 1,
 		"thwart_cost": 1,
 		"traits": "Captive. Hero for Hire.",
@@ -1099,7 +1099,7 @@
 		"quantity": 1,
 		"set_code": "taskmaster",
 		"set_position": 11,
-		"text": "Attach to Taskmaster.\n[star] Taskmaster's attacks gain piercing.\n<b>Hero Action:</b> Exhaust your hero and spend [mental][physical] resources → discard this card.",
+		"text": "Attach to Taskmaster.\n[star] Taskmaster's attacks gain piercing.\n<b>Hero Action</b>: Exhaust your hero and spend [mental][physical] resources → discard this card.",
 		"traits": "Weapon.",
 		"type_code": "attachment"
 	},
@@ -1117,7 +1117,7 @@
 		"quantity": 1,
 		"set_code": "taskmaster",
 		"set_position": 12,
-		"text": "Attach to Taskmaster.\nTaskmaster gains retaliate 1.\n<b>Hero Action:</b> Exhaust your hero and spend [mental][physical] resources → discard this card.",
+		"text": "Attach to Taskmaster.\nTaskmaster gains retaliate 1.\n<b>Hero Action</b>: Exhaust your hero and spend [mental][physical] resources → discard this card.",
 		"traits": "Armor. Weapon.",
 		"type_code": "attachment"
 	},
@@ -1133,7 +1133,7 @@
 		"quantity": 2,
 		"set_code": "taskmaster",
 		"set_position": 13,
-		"text": "Attach to Taskmaster.\n<b>Forced Interrupt:</b> when a player attacks Taskmaster, prevent all damage that would be dealt to Taskmaster and deal an equal amount of damage to that player's identity instead. Then, discard Photographic Reflexes. (Max once per attack.)",
+		"text": "Attach to Taskmaster.\n<b>Forced Interrupt</b>: when a player attacks Taskmaster, prevent all damage that would be dealt to Taskmaster and deal an equal amount of damage to that player's identity instead. Then, discard Photographic Reflexes. (Max once per attack.)",
 		"type_code": "attachment"
 	},
 	{
@@ -1148,7 +1148,7 @@
 		"quantity": 2,
 		"set_code": "taskmaster",
 		"set_position": 15,
-		"text": "<b>When Revealed (Alter-Ego):</b> Discard the top 5 cards of your deck. If a [[Thwart]] card was discarded this way, Taskmaster schemes.\n<b>When Revealed (Hero):</b> Discard the top 5 cards of your deck. If an [[Attack]] card was discarded this way, Taskmaster attacks you.",
+		"text": "<b>When Revealed (Alter-Ego)</b>: Discard the top 5 cards of your deck. If a [[Thwart]] card was discarded this way, Taskmaster schemes.\n<b>When Revealed (Hero)</b>: Discard the top 5 cards of your deck. If an [[Attack]] card was discarded this way, Taskmaster attacks you.",
 		"type_code": "treachery"
 	},
 	{
@@ -1164,7 +1164,7 @@
 		"quantity": 2,
 		"set_code": "taskmaster",
 		"set_position": 17,
-		"text": "Incite 1. <i>(When this card is revealed place 1 threat on the main scheme.)</i>\n<b>When Revealed:</b> Each player in hero form takes 1 damage and discards 1 card at random from their hand.",
+		"text": "Incite 1. <i>(When this card is revealed place 1 threat on the main scheme.)</i>\n<b>When Revealed</b>: Each player in hero form takes 1 damage and discards 1 card at random from their hand.",
 		"type_code": "treachery"
 	},
 	{
@@ -1182,7 +1182,7 @@
 		"scheme_acceleration": 1,
 		"set_code": "taskmaster",
 		"set_position": 19,
-		"text": "<b>When Revealed:</b> Place 1 random set-aside [[Captive]] ally facedown beneath this scheme. When this scheme is defeated, the player who defeated it takes that ally into their hand and removes this scheme from the game.",
+		"text": "<b>When Revealed</b>: Place 1 random set-aside [[Captive]] ally facedown beneath this scheme. When this scheme is defeated, the player who defeated it takes that ally into their hand and removes this scheme from the game.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1200,7 +1200,7 @@
 		"scheme_hazard": 1,
 		"set_code": "taskmaster",
 		"set_position": 23,
-		"text": "<b>Forced Response:</b> After a minion enters play, give it a tough status card.",
+		"text": "<b>Forced Response</b>: After a minion enters play, give it a tough status card.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1220,7 +1220,7 @@
 		"scheme": 2,
 		"set_code": "zola",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "Retaliate 1.",
 		"traits": "Android. Hydra.",
 		"type_code": "villain"
@@ -1241,8 +1241,8 @@
 		"scheme": 2,
 		"set_code": "zola",
 		"set_position": 2,
-		"stage": 2,
-		"text": "Retaliate 1.\n<b>When Revealed:</b> Search the encounter deck and discard pile for the Test Subjects side scheme and reveal it.\n(Shuffle the encounter deck.)",
+		"stage": "II",
+		"text": "Retaliate 1.\n<b>When Revealed</b>: Search the encounter deck and discard pile for the Test Subjects side scheme and reveal it.\n(Shuffle the encounter deck.)",
 		"traits": "Android. Hydra.",
 		"type_code": "villain"
 	},
@@ -1262,8 +1262,8 @@
 		"scheme": 3,
 		"set_code": "zola",
 		"set_position": 3,
-		"stage": 3,
-		"text": "Retaliate 1.\n<b>When Revealed:</b> Each player searches the encounter deck and discard pile for a minion and reveals it. (Shuffle the encounter deck.)",
+		"stage": "III",
+		"text": "Retaliate 1.\n<b>When Revealed</b>: Each player searches the encounter deck and discard pile for a minion and reveals it. (Shuffle the encounter deck.)",
 		"traits": "Android. Hydra.",
 		"type_code": "villain"
 	},
@@ -1279,8 +1279,8 @@
 		"quantity": 1,
 		"set_code": "zola",
 		"set_position": 4,
-		"stage": 1,
-		"text": "<b>Contents:</b> Zola (I) and Zola (II). Zola and Standard encounter sets. One modular encounter set <i>(Under Attack)</i>\n<b>Setup:</b> Search the encounter deck for Hydra Prison and reveal it. Each player searches the encounter deck for a copy of Ultimate Bio-Servant and puts it into play engaged with them. Shuffle the encounter deck.",
+		"stage": "1A",
+		"text": "<b>Contents</b>: Zola (I) and Zola (II). Zola and Standard encounter sets. One modular encounter set <i>(Under Attack)</i>\n<b>Setup</b>: Search the encounter deck for Hydra Prison and reveal it. Each player searches the encounter deck for a copy of Ultimate Bio-Servant and puts it into play engaged with them. Shuffle the encounter deck.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -1299,7 +1299,7 @@
 		"quantity": 1,
 		"set_code": "zola",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1B",
 		"text": "[star] <b>Forced Response</b>: After resolving step one of the villain phase, place 1 test counter here. Then, if there are 3 or more test counters here, discard cards from the top of the encounter deck until a minion is discarded. Put that minion into play engaged with the first player and remove 3 test counters from this scheme.",
 		"threat": 6,
 		"type_code": "main_scheme"
@@ -1317,8 +1317,8 @@
 		"quantity": 1,
 		"set_code": "zola",
 		"set_position": 5,
-		"stage": 2,
-		"text": "<b>When Revealed:</b> Each player searches the encounter deck and discard pile for a minion and reveals it. Shuffle the encounter deck.",
+		"stage": "2A",
+		"text": "<b>When Revealed</b>: Each player searches the encounter deck and discard pile for a minion and reveals it. Shuffle the encounter deck.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -1336,7 +1336,7 @@
 		"quantity": 1,
 		"set_code": "zola",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2B",
 		"text": "[star] <b>Forced Response</b>: After resolving step 1 of the villain phase, place 1 test counter here. Then, if there are 3 or more test counters here, discard cards from the top of the encounter deck until a minion is discarded. Put that minion into play engaged with the first player and remove 3 test counters from this scheme.\n<b>If this scheme is completed, the players lose the game.</b>",
 		"threat": 8,
 		"type_code": "main_scheme"
@@ -1376,7 +1376,7 @@
 		"scheme": 1,
 		"set_code": "zola",
 		"set_position": 10,
-		"text": "<b>When Revealed:</b> Discard cards from the top of the encounter deck until a [[Tech]] attachment is discarded. Attach that card to Zola's Mutate.\n<hr />\n[star] <b>Boost</b>: Shuffle Zola's Mutate into the encounter deck.",
+		"text": "<b>When Revealed</b>: Discard cards from the top of the encounter deck until a [[Tech]] attachment is discarded. Attach that card to Zola's Mutate.\n<hr />\n[star] <b>Boost</b>: Shuffle Zola's Mutate into the encounter deck.",
 		"traits": "Hydra. Mutate.",
 		"type_code": "minion"
 	},
@@ -1462,7 +1462,7 @@
 		"quantity": 3,
 		"set_code": "zola",
 		"set_position": 23,
-		"text": "<b>When Revealed (Alter-Ego):</b> Zola schemes. You are confused.\n<b>When Revealed (Hero):</b> Zola attacks you. You are stunned.",
+		"text": "<b>When Revealed (Alter-Ego)</b>: Zola schemes. You are confused.\n<b>When Revealed (Hero)</b>: Zola attacks you. You are stunned.",
 		"type_code": "treachery"
 	},
 	{
@@ -1477,7 +1477,7 @@
 		"quantity": 2,
 		"set_code": "zola",
 		"set_position": 26,
-		"text": "Incite 1.\n<b>When Revealed:</b> Place 1 test counter on the main scheme.\n<hr />\n[star] <b>Boost</b>: Place 1 test counter on the main scheme.",
+		"text": "Incite 1.\n<b>When Revealed</b>: Place 1 test counter on the main scheme.\n<hr />\n[star] <b>Boost</b>: Place 1 test counter on the main scheme.",
 		"type_code": "treachery"
 	},
 	{
@@ -1493,7 +1493,7 @@
 		"quantity": 1,
 		"set_code": "zola",
 		"set_position": 28,
-		"text": "<b>When Revealed:</b> Each player searches their deck, discard pile and hand for a hero-specific ally and places it facedown beneath this scheme. Place X threat on this scheme where X is the total cost of all allies beneath it. Each player shuffles their deck.\n<b>When Defeated:</b> remove this scheme from the game and return each ally beneath it to its owner's hand.",
+		"text": "<b>When Revealed</b>: Each player searches their deck, discard pile and hand for a hero-specific ally and places it facedown beneath this scheme. Place X threat on this scheme where X is the total cost of all allies beneath it. Each player shuffles their deck.\n<b>When Defeated</b>: remove this scheme from the game and return each ally beneath it to its owner's hand.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1511,7 +1511,7 @@
 		"scheme_hazard": 1,
 		"set_code": "zola",
 		"set_position": 29,
-		"text": "<b>When Defeated:</b> The first player discards cards from the top of the encounter deck until they discard a minion. Reveal that minion.",
+		"text": "<b>When Defeated</b>: The first player discards cards from the top of the encounter deck until they discard a minion. Reveal that minion.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1529,7 +1529,7 @@
 		"scheme_acceleration": 1,
 		"set_code": "zola",
 		"set_position": 31,
-		"text": "<b>Forced Response:</b> After a minion enters play, attach the topmost [[Tech]] attachment in the encounter discard pile to that minion.",
+		"text": "<b>Forced Response</b>: After a minion enters play, attach the topmost [[Tech]] attachment in the encounter discard pile to that minion.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1550,7 +1550,7 @@
 		"scheme": 2,
 		"set_code": "red_skull",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "I",
 		"text": "[star] Red Skull gets +1 ATK for each side scheme in play.",
 		"traits": "Hydra.",
 		"type_code": "villain"
@@ -1573,8 +1573,8 @@
 		"scheme": 3,
 		"set_code": "red_skull",
 		"set_position": 2,
-		"stage": 2,
-		"text": "[star] Red Skull gets +1 ATK for each side scheme in play.\n<b>When Revealed:</b> Deal each player an encounter card.",
+		"stage": "II",
+		"text": "[star] Red Skull gets +1 ATK for each side scheme in play.\n<b>When Revealed</b>: Deal each player an encounter card.",
 		"traits": "Hydra.",
 		"type_code": "villain"
 	},
@@ -1596,8 +1596,8 @@
 		"scheme": 3,
 		"set_code": "red_skull",
 		"set_position": 3,
-		"stage": 3,
-		"text": "[star] Red Skull gets +1 ATK for each side scheme in play.\n<b>When Revealed:</b> Deal each player an encounter card.",
+		"stage": "III",
+		"text": "[star] Red Skull gets +1 ATK for each side scheme in play.\n<b>When Revealed</b>: Deal each player an encounter card.",
 		"traits": "Hydra.",
 		"type_code": "villain"
 	},
@@ -1613,8 +1613,8 @@
 		"quantity": 1,
 		"set_code": "red_skull",
 		"set_position": 4,
-		"stage": 1,
-		"text": "<b>Contents:</b> Red Skull (I) and Red Skull (II). Red Skull and Standard encounter sets. Two modular encounter sets <i>(Hydra Assault and Hydra Patrol).</i>\n<b>Setup:</b> Put the Red House into play. Shuffle every other side scheme into the side-scheme deck and set it next to the encounter deck (see insert).\nSet The Sleeper aside, out of play.",
+		"stage": "1A",
+		"text": "<b>Contents</b>: Red Skull (I) and Red Skull (II). Red Skull and Standard encounter sets. Two modular encounter sets <i>(Hydra Assault and Hydra Patrol).</i>\n<b>Setup</b>: Put the Red House into play. Shuffle every other side scheme into the side-scheme deck and set it next to the encounter deck (see insert).\nSet The Sleeper aside, out of play.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -1634,7 +1634,7 @@
 		"quantity": 1,
 		"set_code": "red_skull",
 		"set_position": 4,
-		"stage": 1,
+		"stage": "1B",
 		"text": "[star] <b>Forced Response</b>: After resolving step one of the villain phase, reveal the top of the side-scheme deck and put it into play.",
 		"threat": 8,
 		"type_code": "main_scheme"
@@ -1652,8 +1652,8 @@
 		"quantity": 1,
 		"set_code": "red_skull",
 		"set_position": 5,
-		"stage": 2,
-		"text": "<b>When Revealed:</b> Reveal the top card of the side-scheme deck and put it into play.",
+		"stage": "2A",
+		"text": "<b>When Revealed</b>: Reveal the top card of the side-scheme deck and put it into play.",
 		"type_code": "main_scheme"
 	},
 	{
@@ -1671,7 +1671,7 @@
 		"quantity": 1,
 		"set_code": "red_skull",
 		"set_position": 5,
-		"stage": 2,
+		"stage": "2B",
 		"text": "[star] <b>Forced Response</b>: After resolving step one of the villain phase, reveal the top card of the side-scheme deck and put it into play.\n<b>If this scheme is completed, the players lose the game.</b>",
 		"threat": 11,
 		"type_code": "main_scheme"
@@ -1693,7 +1693,7 @@
 		"scheme": 1,
 		"set_code": "red_skull",
 		"set_position": 6,
-		"text": "Guard. Retaliate 1. Toughness.\n<b>When Revealed:</b> The Sleeper engages the first player.\n<b>When Defeated:</b> Remove The Sleeper from the game.",
+		"text": "Guard. Retaliate 1. Toughness.\n<b>When Revealed</b>: The Sleeper engages the first player.\n<b>When Defeated</b>: Remove The Sleeper from the game.",
 		"traits": "Elite. Hydra. Robot.",
 		"type_code": "minion"
 	},
@@ -1733,7 +1733,7 @@
 		"scheme": 1,
 		"set_code": "red_skull",
 		"set_position": 10,
-		"text": "Attach to Red Skull.\n[star] Red Skull's attacks gain piercing and ranged.\n<b>Hero Action:</b> Spend [energy] [mental] [physical] resources → discard this card.\n<hr />\n[star] <b>Boost</b>: Attach to Red Skull.",
+		"text": "Attach to Red Skull.\n[star] Red Skull's attacks gain piercing and ranged.\n<b>Hero Action</b>: Spend [energy] [mental] [physical] resources → discard this card.\n<hr />\n[star] <b>Boost</b>: Attach to Red Skull.",
 		"traits": "Weapon.",
 		"type_code": "attachment"
 	},
@@ -1750,7 +1750,7 @@
 		"quantity": 2,
 		"set_code": "red_skull",
 		"set_position": 11,
-		"text": "Attach to Red Skull.\nRed Skull gains retaliate 1.\n<b>Hero Action:</b> Spend [energy][mental][physical] resources → discard this card.",
+		"text": "Attach to Red Skull.\nRed Skull gains retaliate 1.\n<b>Hero Action</b>: Spend [energy][mental][physical] resources → discard this card.",
 		"traits": "Skill.",
 		"type_code": "attachment"
 	},
@@ -1787,7 +1787,7 @@
 		"quantity": 2,
 		"set_code": "red_skull",
 		"set_position": 15,
-		"text": "Incite 1.\nAttach to a side scheme.\n<b>Forced Interrupt:</b> When attached side scheme is defeated, deal the first player an encounter card.",
+		"text": "Incite 1.\nAttach to a side scheme.\n<b>Forced Interrupt</b>: When attached side scheme is defeated, deal the first player an encounter card.",
 		"traits": "Condition.",
 		"type_code": "attachment"
 	},
@@ -1804,7 +1804,7 @@
 		"quantity": 2,
 		"set_code": "red_skull",
 		"set_position": 17,
-		"text": "<b>When Revealed:</b> Exhaust a character you control for each side scheme in play.\n<hr />\n[star] <b>Boost</b>: Exhaust a character you control.",
+		"text": "<b>When Revealed</b>: Exhaust a character you control for each side scheme in play.\n<hr />\n[star] <b>Boost</b>: Exhaust a character you control.",
 		"type_code": "treachery"
 	},
 	{
@@ -1821,7 +1821,7 @@
 		"quantity": 2,
 		"set_code": "red_skull",
 		"set_position": 19,
-		"text": "<b>When Revealed:</b> Place 2 threat on each scheme in play.\n<hr />\n[star] <b>Boost</b>: Give Red Skull a tough status card.",
+		"text": "<b>When Revealed</b>: Place 2 threat on each scheme in play.\n<hr />\n[star] <b>Boost</b>: Give Red Skull a tough status card.",
 		"type_code": "treachery"
 	},
 	{
@@ -1836,7 +1836,7 @@
 		"quantity": 2,
 		"set_code": "red_skull",
 		"set_position": 21,
-		"text": "<b>When Revealed (Alter-Ego):</b> Give Red Skull a tough status card. Red Skull schemes.\n<b>When Revealed (Hero):</b> Give Red Skull a tough status card. Red Skull attacks you.",
+		"text": "<b>When Revealed (Alter-Ego)</b>: Give Red Skull a tough status card. Red Skull schemes.\n<b>When Revealed (Hero)</b>: Give Red Skull a tough status card. Red Skull attacks you.",
 		"type_code": "treachery"
 	},
 	{
@@ -1853,7 +1853,7 @@
 		"quantity": 1,
 		"set_code": "red_skull",
 		"set_position": 23,
-		"text": "Red Skull cannot take damage.\n<b>Interrupt:</b> When a character thwarts this side scheme, they may use their ATK instead of their THW.",
+		"text": "Red Skull cannot take damage.\n<b>Interrupt</b>: When a character thwarts this side scheme, they may use their ATK instead of their THW.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1870,7 +1870,7 @@
 		"quantity": 1,
 		"set_code": "red_skull",
 		"set_position": 24,
-		"text": "This scheme cannot leave play while The Sleeper is in play.\n<b>When Revealed:</b> Put The Sleeper into play engaged with the first player. When The Sleeper is defeated, remove this card from the game.",
+		"text": "This scheme cannot leave play while The Sleeper is in play.\n<b>When Revealed</b>: Put The Sleeper into play engaged with the first player. When The Sleeper is defeated, remove this card from the game.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1887,7 +1887,7 @@
 		"scheme_acceleration": 1,
 		"set_code": "red_skull",
 		"set_position": 25,
-		"text": "<b>When Defeated:</b> The player who defeated this scheme searches their deck and discard pile for an ally, puts it into play, and shuffles their deck.",
+		"text": "<b>When Defeated</b>: The player who defeated this scheme searches their deck and discard pile for an ally, puts it into play, and shuffles their deck.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1903,7 +1903,7 @@
 		"scheme_acceleration": 1,
 		"set_code": "red_skull",
 		"set_position": 26,
-		"text": "<b>When Defeated:</b> Each player chooses up to 3 cards in their discard pile and shuffles them into their deck.",
+		"text": "<b>When Defeated</b>: Each player chooses up to 3 cards in their discard pile and shuffles them into their deck.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1920,7 +1920,7 @@
 		"scheme_hazard": 1,
 		"set_code": "red_skull",
 		"set_position": 27,
-		"text": "<b>When Defeated:</b> The player who defeated this scheme discards a non-<b>Elite</b> minion.",
+		"text": "<b>When Defeated</b>: The player who defeated this scheme discards a non-<b>Elite</b> minion.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1937,7 +1937,7 @@
 		"scheme_crisis": 1,
 		"set_code": "red_skull",
 		"set_position": 28,
-		"text": "<b>When Revealed:</b> Each player discards the top 5 cards of their deck and places 1 threat here for each different type of resource icon ([energy],[mental],[physical], or [wild]) they discarded this way.",
+		"text": "<b>When Revealed</b>: Each player discards the top 5 cards of their deck and places 1 threat here for each different type of resource icon ([energy],[mental],[physical], or [wild]) they discarded this way.",
 		"type_code": "side_scheme"
 	},
 	{
@@ -1956,7 +1956,7 @@
 		"scheme": 1,
 		"set_code": "hydra_assault",
 		"set_position": 1,
-		"text": "[star] <b>Forced Response:</b> After Hydra Flame-Soldier makes an undefended attack against you, discard a support you control.\n<hr />\n[star] <b>Boost</b>: If this card resolves during an undefended attack, discard a support you control.",
+		"text": "[star] <b>Forced Response</b>: After Hydra Flame-Soldier makes an undefended attack against you, discard a support you control.\n<hr />\n[star] <b>Boost</b>: If this card resolves during an undefended attack, discard a support you control.",
 		"traits": "Hydra.",
 		"type_code": "minion"
 	},
@@ -1991,7 +1991,7 @@
 		"quantity": 1,
 		"set_code": "hydra_assault",
 		"set_position": 6,
-		"text": "<b>When Revealed:</b> Each [[Hydra]] minion engaged with a hero attacks that hero. Each player who was not attacked this way searches the encounter deck and discard pile for a [[Hydra]] minion and puts it into play engaged with them. Shuffle the encounter deck if it was searched.",
+		"text": "<b>When Revealed</b>: Each [[Hydra]] minion engaged with a hero attacks that hero. Each player who was not attacked this way searches the encounter deck and discard pile for a [[Hydra]] minion and puts it into play engaged with them. Shuffle the encounter deck if it was searched.",
 		"type_code": "treachery"
 	},
 	{
@@ -2008,7 +2008,7 @@
 		"quantity": 1,
 		"set_code": "weap_master",
 		"set_position": 1,
-		"text": "Attach to the villain.\n[star] Attached villain's attacks gain piercing.\n<b>Hero Action:</b> Spend [mental][physical] resources → discard this card.",
+		"text": "Attach to the villain.\n[star] Attached villain's attacks gain piercing.\n<b>Hero Action</b>: Spend [mental][physical] resources → discard this card.",
 		"traits": "Weapon.",
 		"type_code": "attachment"
 	},
@@ -2026,7 +2026,7 @@
 		"quantity": 1,
 		"set_code": "weap_master",
 		"set_position": 2,
-		"text": "Attach to the Villain.\n[star] <b>Forced Interrupt:</b> When attached villain attacks, the attack gains ranged.\n<b>Hero Action:</b> Spend [mental][physical] resources → discard this card.",
+		"text": "Attach to the Villain.\n[star] <b>Forced Interrupt</b>: When attached villain attacks, the attack gains ranged.\n<b>Hero Action</b>: Spend [mental][physical] resources → discard this card.",
 		"traits": "Weapon.",
 		"type_code": "attachment"
 	},
@@ -2042,7 +2042,7 @@
 		"quantity": 2,
 		"set_code": "weap_master",
 		"set_position": 3,
-		"text": "<b>When Reveled (Alter-Ego):</b> The villain schemes. If they have a [[Weapon]] attachment, this card gains surge.\n<b>When Reveled (Hero):</b> the villain attacks you. If they have a [[Weapon]] attachment, this card gains surge.",
+		"text": "<b>When Reveled (Alter-Ego)</b>: The villain schemes. If they have a [[Weapon]] attachment, this card gains surge.\n<b>When Reveled (Hero)</b>: the villain attacks you. If they have a [[Weapon]] attachment, this card gains surge.",
 		"type_code": "treachery"
 	},
 	{
@@ -2057,7 +2057,7 @@
 		"quantity": 1,
 		"set_code": "weap_master",
 		"set_position": 5,
-		"text": "<b>When Revealed (Alter-Ego):</b> You are confused. Place 1 threat on the main scheme (2 threat instead if you were already confused).\n<b>When Revealed (Hero):</b> You are stunned. Deal 1 damage to your hero (2 instead if you were already stunned).",
+		"text": "<b>When Revealed (Alter-Ego)</b>: You are confused. Place 1 threat on the main scheme (2 threat instead if you were already confused).\n<b>When Revealed (Hero)</b>: You are stunned. Deal 1 damage to your hero (2 instead if you were already stunned).",
 		"type_code": "treachery"
 	},
 	{
@@ -2093,7 +2093,7 @@
 		"scheme": 1,
 		"set_code": "hydra_patrol",
 		"set_position": 3,
-		"text": "Guard.<i>(While this minion is engaged with you, you cannot attack the villain.)</i>\n<b>When Defeated:</b> Deal the engaged player an encounter card.",
+		"text": "Guard.<i>(While this minion is engaged with you, you cannot attack the villain.)</i>\n<b>When Defeated</b>: Deal the engaged player an encounter card.",
 		"traits": "Hydra.",
 		"type_code": "minion"
 	},
@@ -2112,7 +2112,7 @@
 		"scheme_crisis": 1,
 		"set_code": "hydra_patrol",
 		"set_position": 6,
-		"text": "<b>When Defeated:</b> Each player searches the encounter deck and discard pile for a [[Hydra]] minion and puts it into play engaged with them. Shuffle the encounter deck.",
+		"text": "<b>When Defeated</b>: Each player searches the encounter deck and discard pile for a [[Hydra]] minion and puts it into play engaged with them. Shuffle the encounter deck.",
 		"type_code": "side_scheme"
 	}
 ]

--- a/pack/twc_encounter.json
+++ b/pack/twc_encounter.json
@@ -10,7 +10,7 @@
 		"quantity": 1,
 		"set_code": "wrecking_crew",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "1A",
 		"text": "<b>Scenario Contents</b>: Wrecker A, Thunderball A, Piledriver A, and Bulldozer A as villains. <i>(Version B for increased difficulty.)</i> Wrecker, Thunderball, Piledriver, and Bulldozer encounter decks.\n<b>Setup</b>: Put the Day of Reckoning, Thunderstruck, Pile It On!, and Clear the Road side schemes into play. Place the active counter on Wrecker. Advance to stage 1B.",
 		"type_code": "main_scheme"
 	},
@@ -30,7 +30,7 @@
 		"quantity": 1,
 		"set_code": "wrecking_crew",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "1B",
 		"text": "[star] <b>Forced Response</b>: After step one of the villain phase, place 1 threat on each side scheme. Move the active counter to the villain whose scheme has the most threat. <i>(If there is a tie, the first player chooses.)</i>\n<b>If this stage is completed, the players lose the game</b>",
 		"threat": 6,
 		"type_code": "main_scheme"
@@ -52,7 +52,7 @@
 		"scheme_star": true,
 		"set_code": "wrecker",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "A",
 		"text": "[star] When Wrecker schemes, place the threat on his side scheme instead of the main scheme.\n[star] While Wrecker is attacking, he gets +2 ATK if the attack is undefended.",
 		"traits": "Wrecking Crew.",
 		"type_code": "villain"
@@ -74,7 +74,7 @@
 		"scheme_star": true,
 		"set_code": "wrecker",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "B",
 		"text": "[star] When Wrecker schemes, place the threat on his side scheme instead of the main scheme.\n[star] While Wrecker is attacking, he gets +2 ATK if the attack is undefended.",
 		"traits": "Wrecking Crew.",
 		"type_code": "villain"
@@ -292,7 +292,7 @@
 		"scheme_star": true,
 		"set_code": "thunderball",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "A",
 		"text": "[star] When Thunderball schemes, place the threat on his side scheme instead of the main scheme.\n[star] <b>Forced Response</b>: After Thunderball attacks you, deal 1 damage to each character you control.",
 		"traits": "Wrecking Crew.",
 		"type_code": "villain"
@@ -314,7 +314,7 @@
 		"scheme_star": true,
 		"set_code": "thunderball",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "B",
 		"text": "[star] When Thunderball schemes, place the threat on his side scheme instead of the main scheme.\n[star] <b>Forced Response</b>: After Thunderball attacks you, deal 1 damage to each character you control.",
 		"traits": "Wrecking Crew.",
 		"type_code": "villain"
@@ -532,7 +532,7 @@
 		"scheme_star": true,
 		"set_code": "piledriver",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "A",
 		"text": "Retaliate 1.\n[star] When Piledriver schemes, place the threat on his side scheme instead of the main scheme.",
 		"traits": "Wrecking Crew.",
 		"type_code": "villain"
@@ -553,7 +553,7 @@
 		"scheme_star": true,
 		"set_code": "piledriver",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "B",
 		"text": "Retaliate 1.\n[star] When Piledriver schemes, place the threat on his side scheme instead of the main scheme.",
 		"traits": "Wrecking Crew.",
 		"type_code": "villain"
@@ -752,7 +752,7 @@
 		"scheme_star": true,
 		"set_code": "bulldozer",
 		"set_position": 1,
-		"stage": 1,
+		"stage": "A",
 		"text": "[star] When Bulldozer schemes, place the threat on his side scheme instead of the main scheme.\n[star] <b>Forced Interrupt</b>: When Bulldozer attacks, the attack gains overkill.",
 		"traits": "Wrecking Crew.",
 		"type_code": "villain"
@@ -774,7 +774,7 @@
 		"scheme_star": true,
 		"set_code": "bulldozer",
 		"set_position": 2,
-		"stage": 2,
+		"stage": "B",
 		"text": "[star] When Bulldozer schemes, place the threat on his side scheme instead of the main scheme.\n[star] <b>Forced Interrupt</b>: When Bulldozer attacks, the attack gains overkill.",
 		"traits": "Wrecking Crew.",
 		"type_code": "villain"

--- a/schema/card_schema.json
+++ b/schema/card_schema.json
@@ -253,15 +253,8 @@
 			"type": "string"
 		},
 		"stage": {
-			"oneOf": [
-				{
-					"minimum": 0,
-					"type": "integer"
-				},
-				{
-					"type": "null"
-				}
-			]
+			"minLength": 1,
+			"type": "string"
 		},
 		"subname": {
 			"minLength": 1,


### PR DESCRIPTION
**Requires https://github.com/zzorba/marvelsdb/pull/326 to be merged first**

The `stage` column was an integer property but that didn't allow values like "A", "B1", "III", etc. This PR converts all `stage` properties to a string value and fixes missing or incorrect values for existing villains and main schemes.

I found a few `:</b>` instances in files that I was updating so I changed them to `</b>:` to put the colon outside of the bold text on cards.

Here are some examples of cards that we can now support.

[Arclight - 40070a](https://marvelcdb.com/card/40070a)
<img width="397" alt="Screenshot 2025-06-25 at 10 11 59 PM" src="https://github.com/user-attachments/assets/1d8ea64c-0c48-4bd3-a21c-316b4c39e0b7" />

[Knock, Knock - 40077](https://marvelcdb.com/card/40077)
<img width="395" alt="Screenshot 2025-06-25 at 10 12 20 PM" src="https://github.com/user-attachments/assets/7893721b-60bc-4308-8c7e-a6b0f566e50a" />

[Hela - 21136a](https://marvelcdb.com/card/21136a)
<img width="397" alt="Screenshot 2025-06-25 at 10 12 42 PM" src="https://github.com/user-attachments/assets/1b4b5ab4-001e-46ef-a77d-0c0a238dcb28" />

[Skies Over New York - 27116a](https://marvelcdb.com/card/27116a)
<img width="394" alt="Screenshot 2025-06-25 at 10 13 10 PM" src="https://github.com/user-attachments/assets/336ebf88-4825-49b8-b880-eda25825ba8f" />
