### PR TITLE
Fix quantity for Symbiotic Monstrosity in SM pack

### DIFF
--- a/pack/sm_encounter.json
+++ b/pack/sm_encounter.json
@@ -1447,7 +1447,7 @@
 		"octgn_id": "4dc840fa-521c-409d-b57c-d0b63bd3b22c",
 		"pack_code": "sm",
 		"position": 122,
-		"quantity": 2,
+		"quantity": 1,
 		"scheme": 2,
 		"set_code": "venom_goblin",
 		"set_position": 11,


### PR DESCRIPTION
There is only one copy  of Symbiotic Monstrosity in Sinister Motives

Ref: https://hallofheroeslcg.com/sinister-motives/#venomgoblin