### PR TITLE
Fix multiple quantity errors

### DIFF
--- a/pack/aoa.json
+++ b/pack/aoa.json
@@ -302,7 +302,7 @@
         "octgn_id": "1ab538aa-6ad1-4d9d-83a6-3ebc3a045015",
         "pack_code": "aoa",
         "position": 15,
-        "quantity": 3,
+        "quantity": 1,
         "resource_wild": 1,
         "text": "Attach to an identity-specific ally you control. Max 1 per deck.\nAttached ally gets +2 hit points and is your \"sidekick.\"\n<b>Response</b>: After you make a basic recovery, heal 2 damage from attached ally.",
         "traits": "Title.",

--- a/pack/aoa_encounter.json
+++ b/pack/aoa_encounter.json
@@ -1831,7 +1831,7 @@
         "octgn_id": "1ab538aa-6ad1-4d9d-83a6-3ebc3a045134",
         "pack_code": "aoa",
         "position": 134,
-        "quantity": 3,
+        "quantity": 2,
         "scheme": 2,
         "set_code": "genosha",
         "set_position": 2,
@@ -1855,7 +1855,7 @@
         "quantity": 1,
         "scheme": 1,
         "set_code": "genosha",
-        "set_position": 5,
+        "set_position": 4,
         "text": "Armored Unibike engages the player with Escaped Mutant attached, if able.\n[star] <b>Forced Response</b>: After Armored Unibike attacks, resolve the \"<b>Special</b>\" ability on the [[Setting]] environment.",
         "traits": "Genosha. Vehicle.",
         "type_code": "minion"

--- a/pack/aoa_encounter.json
+++ b/pack/aoa_encounter.json
@@ -1852,7 +1852,7 @@
         "octgn_id": "1ab538aa-6ad1-4d9d-83a6-3ebc3a045135",
         "pack_code": "aoa",
         "position": 135,
-        "quantity": 1,
+        "quantity": 2,
         "scheme": 1,
         "set_code": "genosha",
         "set_position": 4,

--- a/pack/bp.json
+++ b/pack/bp.json
@@ -485,7 +485,7 @@
         "octgn_id": "4010e194-df1c-477e-852e-3a2adf051025",
         "pack_code": "bp",
         "position": 25,
-        "quantity": 2,
+        "quantity": 1,
         "resource_wild": 1,
         "text": "Team-Up (Black Panther/T'Challa and Black Panther/Shuri). Max 1 per deck.\n<b>Hero Action</b>: Search your deck and discard pile for a [[Black Panther]] upgrade and put it into play. Resolve the \"<b>Special</b>\" ability on up to 4 [[Black Panther]] upgrades you control in any order.",
         "traits": "Wakanda.",

--- a/pack/hood_encounter.json
+++ b/pack/hood_encounter.json
@@ -719,7 +719,7 @@
 		"octgn_id": "83344536-ce80-4f24-84e6-bbb1cd090879",
 		"pack_code": "hood",
 		"position": 39,
-		"quantity": 2,
+		"quantity": 1,
 		"set_code": "ransacked_armory",
 		"set_position": 3,
 		"text": "Attach to the minion with the most remaining hit points. If you cannot, this card gains surge.\n<b>Forced Interrupt:</b> When attached minion would take any amount of damage from an attack, discard the top card of the encounter deck. Reduce damage from that attack by the number of boost icons ([boost]) discarded this way.",

--- a/pack/hood_encounter.json
+++ b/pack/hood_encounter.json
@@ -737,9 +737,9 @@
 		"octgn_id": "34fdd8ae-436f-4e4c-9b7b-f321eac43b6d",
 		"pack_code": "hood",
 		"position": 40,
-		"quantity": 1,
+		"quantity": 2,
 		"set_code": "ransacked_armory",
-		"set_position": 5,
+		"set_position": 4,
 		"text": "Attach to the minion with the most remaining hit points. If you cannot, this card gains surge.\nAttach minion gets +3 hit points.\n[star] Attached minion's attacks gain overkill.",
 		"traits": "Tech. Weapon.",
 		"type_code": "attachment"

--- a/pack/jubilee.json
+++ b/pack/jubilee.json
@@ -514,7 +514,7 @@
         "octgn_id": "2bb9367c-944e-4475-b643-6a84c3047028",
         "pack_code": "jubilee",
         "position": 22,
-        "quantity": 1,
+        "quantity": 2,
         "resource_wild": 1,
         "text": "Team-Up (Jubilee and Wolverine). Max 1 per deck.\n<b>Hero Action</b> <i>(attack)</i>: Confuse an enemy. Deal 4 damage to a confused enemy.",
         "traits": "Attack.",

--- a/pack/mut_gen_encounter.json
+++ b/pack/mut_gen_encounter.json
@@ -2151,7 +2151,7 @@
 		"octgn_id": "47d34c5d-5319-45a9-a2d6-1fb975032150",
 		"pack_code": "mut_gen",
 		"position": 150,
-		"quantity": 2,
+		"quantity": 1,
 		"set_code": "magneto_villain",
 		"set_position": 16,
 		"text": "Attach to your identity. Max 1 per identity.\nAttached identity cannot thwart, attack, defend, or recover.\n<b>Action</b>: Exhaust your identity and spend a [physical] resource → discard this card. ",
@@ -2169,7 +2169,7 @@
 		"position": 151,
 		"quantity": 2,
 		"set_code": "magneto_villain",
-		"set_position": 18,
+		"set_position": 17,
 		"text": "<b>When Revealed</b>: Take the topmost [[Magnetic]] card in the encounter discard pile and give it to Magneto as a facedown boost card. Magneto activates against you.",
 		"type_code": "treachery"
 	},

--- a/pack/mut_gen_encounter.json
+++ b/pack/mut_gen_encounter.json
@@ -2167,7 +2167,7 @@
 		"octgn_id": "47d34c5d-5319-45a9-a2d6-1fb975032151",
 		"pack_code": "mut_gen",
 		"position": 151,
-		"quantity": 2,
+		"quantity": 3,
 		"set_code": "magneto_villain",
 		"set_position": 17,
 		"text": "<b>When Revealed</b>: Take the topmost [[Magnetic]] card in the encounter discard pile and give it to Magneto as a facedown boost card. Magneto activates against you.",

--- a/pack/sm_encounter.json
+++ b/pack/sm_encounter.json
@@ -1447,7 +1447,7 @@
 		"octgn_id": "4dc840fa-521c-409d-b57c-d0b63bd3b22c",
 		"pack_code": "sm",
 		"position": 122,
-		"quantity": 2,
+		"quantity": 1,
 		"scheme": 2,
 		"set_code": "venom_goblin",
 		"set_position": 11,


### PR DESCRIPTION
Changes:

- `Sidekick` quantity 3 > 1
- `Heart of the Panther` quantity 2 > 1
- `Unlikely Duo` quantity 1 > 2
- `Armored Unibike` quantity 1 > 2
- `Magistrate` quantity 3 > 2
- `Master of Magnetism` quantity 2 > 3
- `Wrapped in Metal` quantity 2 > 1
- `Symbiotic Monstrosity` quantity 2 > 1
- `Tech Gauntlets` quantity 1 > 2
- `Jetpack` quantity 2 > 1


Fixes zzorba/marvelsdb#310
Fixes zzorba/marvelsdb#323