### PR TITLE
Fix multiple typos

### DIFF
--- a/pack/mojo_encounter.json
+++ b/pack/mojo_encounter.json
@@ -999,7 +999,7 @@
 		"quantity": 1,
 		"set_code": "fantasy",
 		"set_position": 6,
-		"text": "<b>When Defeated</b>: Choose a non-wild (non-[wild]) resource type, then each player draws 2 cards. Each player must discard each card from their hand with the chosen resource type.\n<hr />\n[star] <b>Boost</b>: Discard 1 card from your hand.",
+		"text": "<b>When Revealed</b>: Choose a non-wild (non-[wild]) resource type, then each player draws 2 cards. Each player must discard each card from their hand with the chosen resource type.\n<hr />\n[star] <b>Boost</b>: Discard 1 card from your hand.",
 		"type_code": "treachery"
 	},
 	{

--- a/pack/mts_encounter.json
+++ b/pack/mts_encounter.json
@@ -2151,7 +2151,7 @@
 		"quantity": 1,
 		"set_code": "loki",
 		"set_position": 14,
-		"text": "Attach to Loki.\n<b>Forced Response</b>: When Loki would take damage from an attack, discard the top card of the encounter deck. If that card is a treachery, prevent all damage from this attack and discard this card.",
+		"text": "Attach to Loki.\n<b>Forced Interrupt</b>: When Loki would take damage from an attack, discard the top card of the encounter deck. If that card is a treachery, prevent all damage from this attack and discard this card.",
 		"traits": "Condition.",
 		"type_code": "attachment"
 	},

--- a/pack/mut_gen.json
+++ b/pack/mut_gen.json
@@ -918,7 +918,7 @@
 		"quantity": 1,
 		"set_code": "mut_gen_campaign",
 		"set_position": 3,
-		"text": "<b>When Revealed</b>: Each player searches their deck for an ally and places it facedown under here.\n<b>When Defeated</b>: Shuffle the top card of the Future Past deck into the encounter deck. Flip this card and reveal Rescue Captives. <i>(Keep facedown cards unduer Rescue Captives.)</i>",
+		"text": "<b>When Revealed</b>: Each player searches their deck for an ally and places it facedown under here.\n<b>When Defeated</b>: Shuffle the top card of the Future Past deck into the encounter deck. Flip this card and reveal Rescue Captives. <i>(Keep facedown cards under Rescue Captives.)</i>",
 		"type_code": "side_scheme"
 	},
 	{

--- a/pack/sm_encounter.json
+++ b/pack/sm_encounter.json
@@ -2274,7 +2274,7 @@
 		"quantity": 1,
 		"set_code": "whispers_of_paranoia",
 		"set_position": 4,
-		"text": "Attached minion gets +1 hit point.\n<b>When Revealed</b>: Search the encounter deck, discard pile, and set-aside area for your nemesis minion, then reveal that minion. Attach old Grudge to it (Shuffle.)\n<hr />\n[star] <b>Boost</b>: Deal 1 damage to each character you control.",
+		"text": "Attached minion gets +1 hit point.\n<b>When Revealed</b>: Search the encounter deck, discard pile, and set-aside area for your nemesis minion, then reveal that minion. Attach Old Grudge to it. (Shuffle.)\n<hr />\n[star] <b>Boost</b>: Deal 1 damage to each character you control.",
 		"traits": "Illusion.",
 		"type_code": "attachment"
 	},


### PR DESCRIPTION
Fix typo on 'Old Grugde'
https://hallofheroeslcg.com/wp-content/uploads/2022/03/d.jpg
Fixes zzorba/marvelsdb#322

Fix typo on 'Find the Prisoners'
https://hallofheroeslcg.com/wp-content/uploads/2024/08/32173a.jpg
Fixes zzorba/marvelsdb#321

Fix typo on 'Mana Drain'
https://hallofheroeslcg.com/wp-content/uploads/2022/11/39046.jpg
Fixes zzorba/marvelsdb#319

Fix typo on 'Master of Illusions'
https://hallofheroeslcg.com/wp-content/uploads/2021/08/l14.jpg
Fixes zzorba/marvelsdb#312