### PR TITLE
Fix S.H.I.E.L.D. deputy type

### DIFF
--- a/pack/winter.json
+++ b/pack/winter.json
@@ -474,7 +474,7 @@
         "quantity": 3,
         "resource_mental": 1,
         "text": "Play only if your identity has the [[S.H.I.E.L.D.]] trait.\nAttach to a friendly character.\nAttached character gets +1 hit point and gains the [[S.H.I.E.L.D.]] trait.",
-        "traits": "Weapon.",
+        "traits": "Title.",
         "type_code": "upgrade"
     }
 ]


### PR DESCRIPTION
Correct type of S.H.I.E.L.D. deputy (title, not weapon)