### PR TITLE
[ES] Fix typo "ponlo" in spanish translation sm.json

### DIFF
--- a/translations/es/pack/sm.json
+++ b/translations/es/pack/sm.json
@@ -117,7 +117,7 @@
 	{
 		"code": "27018",
 		"name": "Multiverso arácnido",
-		"text": "Máximo de 1 por mazo.\n<b>Acción de Héroe:</b> agota una carta [[Guerrero Araña]] que controles \u2192 busca un Aliado [[Guerrero Araña]] en tu pila de descartes y pono en juego, luego elige a un jugador. Ese jugador puede gastar 3 recursos de cualquier tipo para volver a usar esta capacidad."
+		"text": "Máximo de 1 por mazo.\n<b>Acción de Héroe:</b> agota una carta [[Guerrero Araña]] que controles \u2192 busca un Aliado [[Guerrero Araña]] en tu pila de descartes y ponlo en juego, luego elige a un jugador. Ese jugador puede gastar 3 recursos de cualquier tipo para volver a usar esta capacidad."
 	},
 	{
 		"code": "27019",


### PR DESCRIPTION
Change word pono in spanish to "ponlo". Typo error.