### PR TITLE
[EN] Correct boost number in Hydra soldier

### DIFF
--- a/pack/core_encounter.json
+++ b/pack/core_encounter.json
@@ -1623,7 +1623,7 @@
 	},
 	{
 		"attack": 2,
-		"boost": 2,
+		"boost": 1,
 		"code": "01182",
 		"faction_code": "encounter",
 		"health": 4,


### PR DESCRIPTION
solved error in display the boost icons in Hydra soldier
PD: please do the update the translations things because the last PR i do not reflect in the website