### PR TITLE
fix typo in Hope Summers name

### DIFF
--- a/pack/next_evol_encounter.json
+++ b/pack/next_evol_encounter.json
@@ -1441,7 +1441,7 @@
         "set_code": "juggernaut",
         "set_position": 4,
         "stage": "1A",
-        "text": "<b>Contents</b>: Juggernaut (I) and Juggernaut (II) <i>(Juggernaut (II) and Juggernaut (III) instead for expert mode)</i>. Juggernaut, Hope Summers, and Standard encounter sets. One modular encounter set <i>(Black Tom Cassidy)</i>.\n<b>Setup</b>: Attach Juggernaut's Helmet to Juggernaut. Put Home Summers into play under the first player's control.",
+        "text": "<b>Contents</b>: Juggernaut (I) and Juggernaut (II) <i>(Juggernaut (II) and Juggernaut (III) instead for expert mode)</i>. Juggernaut, Hope Summers, and Standard encounter sets. One modular encounter set <i>(Black Tom Cassidy)</i>.\n<b>Setup</b>: Attach Juggernaut's Helmet to Juggernaut. Put Hope Summers into play under the first player's control.",
         "type_code": "main_scheme"
     },
     {


### PR DESCRIPTION
There was a typo on the Juggernaut main scheme. It's "Hope Summers" not "Home Summers".