### PR TITLE
Fix typos with cycle 11 packs

### DIFF
--- a/pack/fne.json
+++ b/pack/fne.json
@@ -361,7 +361,7 @@
         "resource_physical": 1,
         "set_code": "daredevil",
         "set_position": 15,
-        "text": "<b>Hero Action</b>: Exhaust this card and deal 1 damage to Daredeveil \u2192 choose:\n\u2022 Choose any upgrade from the [[Sense]] deck and play it, ignoring its resource cost. <i>(Do not shuffle.)</i>\n\u2022 Ready Daredevil.",
+        "text": "<b>Hero Action</b>: Exhaust this card and deal 1 damage to Daredevil \u2192 choose:\n\u2022 Choose any upgrade from the [[Sense]] deck and play it, ignoring its resource cost. <i>(Do not shuffle.)</i>\n\u2022 Ready Daredevil.",
         "traits": "Title.",
         "type_code": "upgrade"
     },

--- a/pack/luke_cage.json
+++ b/pack/luke_cage.json
@@ -268,7 +268,7 @@
         "cost": 3,
         "deck_limit": 1,
         "faction_code": "leadership",
-        "flavor": "\"Come on, hoeroes. We've got to help save this city.\"",
+        "flavor": "\"Come on, heroes. We've got to help save this city.\"",
         "health": 2,
         "is_unique": true,
         "name": "Misty Knight",


### PR DESCRIPTION
Fixes 2 typos with Fear No Evil and Luke Cage packs:
* Daredeveil → Daredevil
* hoeroes → heroes